### PR TITLE
chore(guardrails): add mass-deletion protections and contribution policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,73 @@
+## Description
+
+<!--
+Describe the changes in this PR. What does it do? Why is it needed?
+Be specific — what problem does this solve?
+-->
+
+## SDD Topic Key (if applicable)
+
+<!--
+If this change is tracked via Spec-Driven Development, include the topic_key here.
+Example: sdd/switch-stack-to-vue-firebase
+Leave blank if not an SDD-tracked change.
+-->
+
+**topic_key**: `<!-- e.g. sdd/guardrails-improvement -->`
+
+## Type of Change
+
+<!-- Check all that apply -->
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `chore` — maintenance / tooling
+- [ ] `docs` — documentation only
+- [ ] `refactor` — restructuring without behavior change
+- [ ] `ci` — CI/CD pipeline change
+- [ ] `test` — adding or updating tests
+
+## Checklist
+
+<!-- All boxes must be checked before requesting review -->
+
+### Content Safety
+- [ ] No deletions of top-level directories (`DECISIONS/`, `SPEC/`, `OUTPUTS/`, `PLAN/`)
+- [ ] No more than 10 files deleted (if more, explain why below)
+- [ ] All modified files are intentional (no accidental staging)
+- [ ] No secrets, credentials, or tokens committed
+
+### Code Quality
+- [ ] Code follows project conventions (Vue 3 + TypeScript, conventional commits)
+- [ ] ESLint and TypeScript checks pass locally
+- [ ] Tests pass locally (if applicable)
+- [ ] New code is covered by tests (if applicable)
+
+### Documentation
+- [ ] CONTRIBUTING.md and docs updated if needed
+- [ ] SDD artifacts updated if this is part of a tracked change
+- [ ] PR description explains the "why", not just the "what"
+
+### Review
+- [ ] Self-reviewed the diff — no unintended changes included
+- [ ] Breaking changes documented (if any)
+
+## If More Than 10 Files Were Deleted
+
+<!--
+Explain why the mass-deletion is intentional and has been approved.
+Link to the ADR or discussion that approved this change.
+-->
+
+N/A
+
+## Related Issues / PRs
+
+<!--
+Link any related GitHub issues or previous PRs.
+Example: Closes #42, Related to #38
+-->
+
+---
+
+*This PR template is maintained by @DevXoje. See CONTRIBUTING.md for full policy.*

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,16 @@ Leave blank if not an SDD-tracked change.
 
 **topic_key**: `<!-- e.g. sdd/guardrails-improvement -->`
 
+## Reviewer
+
+<!--
+Tag the primary reviewer for this PR.
+For CODEOWNERS-protected paths (DECISIONS/, SPEC/, OUTPUTS/, PLAN/) @DevXoje
+is automatically requested.
+-->
+
+**Reviewer**: @<!-- tag reviewer here -->
+
 ## Type of Change
 
 <!-- Check all that apply -->
@@ -32,8 +42,8 @@ Leave blank if not an SDD-tracked change.
 <!-- All boxes must be checked before requesting review -->
 
 ### Content Safety
-- [ ] No deletions of top-level directories (`DECISIONS/`, `SPEC/`, `OUTPUTS/`, `PLAN/`)
-- [ ] No more than 10 files deleted (if more, explain why below)
+- [ ] No deletions of `AGENTS/`, `DECISIONS/`, `SPEC/`, `OUTPUTS/`, `PLAN/` unless explicitly approved via ADR/issue
+- [ ] No more than 15 files deleted (if more, explain why below)
 - [ ] All modified files are intentional (no accidental staging)
 - [ ] No secrets, credentials, or tokens committed
 
@@ -52,7 +62,7 @@ Leave blank if not an SDD-tracked change.
 - [ ] Self-reviewed the diff — no unintended changes included
 - [ ] Breaking changes documented (if any)
 
-## If More Than 10 Files Were Deleted
+## If More Than 15 Files Were Deleted
 
 <!--
 Explain why the mass-deletion is intentional and has been approved.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,28 @@
+# CODEOWNERS — gerocultores-system
+#
+# This file defines code owners for critical paths in the repository.
+# Code owners are automatically requested for review when a pull request
+# modifies files in their owned paths.
+#
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything not matched below
+* @DevXoje
+
+# SDD Artifact directories — critical, require explicit review
+DECISIONS/* @DevXoje
+SPEC/* @DevXoje
+OUTPUTS/* @DevXoje
+PLAN/* @DevXoje
+
+# Security-sensitive files
+SECURITY/* @DevXoje
+
+# Repository governance files
+CONTRIBUTING.md @DevXoje
+CODEOWNERS @DevXoje
+.github/* @DevXoje
+.github/workflows/* @DevXoje
+
+# Pre-commit templates and tooling
+TOOLS/* @DevXoje

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,210 @@
+# Contributing to gerocultores-system
+
+> **Authors**: Jose Vilches Sánchez (developer) / ANDRES MARTOS GAZQUEZ (tutor)  
+> **Project**: DAW Final Project — Sistema de Gestión para Gerocultores  
+> **Repository**: https://github.com/DevXoje/gerocultores-system
+
+---
+
+## Table of Contents
+
+1. [Branch Policy — No Direct Pushes to `master`](#branch-policy)
+2. [Commit Message Conventions](#commit-message-conventions)
+3. [Pull Request Requirements](#pull-request-requirements)
+4. [Mass-Deletion Guardrail](#mass-deletion-guardrail)
+5. [Pre-commit Hook Setup](#pre-commit-hook-setup)
+6. [Emergency Rollback Procedures](#emergency-rollback-procedures)
+7. [Contact Points](#contact-points)
+
+---
+
+## Branch Policy
+
+**Direct pushes to `master` are NOT allowed.** All changes must go through a Pull Request.
+
+### Rules
+
+| Rule | Details |
+|------|---------|
+| Branch protection | `master` requires at least 1 review before merge |
+| Status checks | CI must pass before merge |
+| No force-push | Never force-push to `master` |
+| No delete | `master` cannot be deleted |
+| Short-lived branches | Feature/fix branches should be merged within the sprint |
+
+### Branch Naming Convention
+
+```
+feat/<short-description>       # new feature
+fix/<short-description>        # bug fix
+chore/<short-description>      # maintenance task
+docs/<short-description>       # documentation only
+refactor/<short-description>   # code restructuring without behavior change
+guardrails/<short-description> # repository protection improvements
+```
+
+Examples:
+- `feat/login-view`
+- `fix/firestore-rules`
+- `guardrails/patch-1`
+
+---
+
+## Commit Message Conventions
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/).
+
+### Format
+
+```
+<type>(<scope>): <short description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+| Type | When to use |
+|------|------------|
+| `feat` | A new feature |
+| `fix` | A bug fix |
+| `chore` | Build process or tooling changes |
+| `docs` | Documentation only |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `test` | Adding or updating tests |
+| `ci` | Changes to CI/CD configuration |
+| `style` | Code style changes (formatting, no logic change) |
+
+### Examples
+
+```
+feat(auth): add Firebase email/password login
+fix(firestore-rules): prevent unauthorized read on incidencias
+chore(deps): upgrade Vue to 3.4.x
+docs(readme): update local setup instructions
+ci(workflows): add mass-deletion guard action
+```
+
+### Scope Reference
+
+Scopes should match the area of the codebase:
+- `auth`, `agenda`, `residentes`, `incidencias`, `turnos`, `notificaciones`
+- `api`, `frontend`, `shared`
+- `ci`, `workflows`, `guardrails`, `deps`, `config`
+
+---
+
+## Pull Request Requirements
+
+All PRs must:
+
+1. **Reference the SDD `topic_key`** if the change is part of a spec-driven change (e.g., `sdd/switch-stack-to-vue-firebase`).
+2. **Fill the PR template** located at `.github/PULL_REQUEST_TEMPLATE.md`.
+3. **Pass CI** — no merging with failing status checks.
+4. **Receive 1 approving review** (self-review is not sufficient for production-critical paths).
+5. **Not mass-delete files** — see [Mass-Deletion Guardrail](#mass-deletion-guardrail).
+
+For guardrail and SDD artifact policy details, refer to `AGENTS/guardrails.md` (if present) or the SDD memory artifacts in Engram under project `gerocultores-system`.
+
+---
+
+## Mass-Deletion Guardrail
+
+### Why This Exists
+
+A prior incident resulted in destructive commits that deleted entire top-level directories (`DECISIONS/`, `SPEC/`, etc.). This policy prevents recurrence.
+
+### Rules
+
+- **Never delete more than 15 files in a single commit** without an explicit justification in the PR description.
+- **Never delete top-level directories** (`AGENTS/`, `DECISIONS/`, `SPEC/`, `OUTPUTS/`, `PLAN/`) without an ADR and explicit approval.
+- If you need to archive/reorganize large amounts of files, do it in a dedicated branch with a detailed PR.
+
+### Pre-commit Hook
+
+A pre-commit hook template is available at `TOOLS/pre-commit-template.sh` that will **abort the commit** if more than 15 files are being deleted at once.
+
+To install it locally:
+
+```bash
+cp TOOLS/pre-commit-template.sh .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+**The hook is NOT installed automatically** to avoid blocking valid operations. It is the developer's responsibility to install it.
+
+---
+
+## Pre-commit Hook Setup
+
+See `TOOLS/pre-commit-template.sh` for the full script. It:
+1. Counts staged deletions.
+2. Aborts the commit if `> 15` files would be deleted.
+3. Also aborts if any file in `AGENTS/`, `DECISIONS/`, `SPEC/`, `OUTPUTS/`, or `PLAN/` is being deleted.
+4. Provides a clear error message explaining how to proceed via a PR instead.
+
+If you need to bypass the hook for a legitimate mass-deletion (e.g., removing a deprecated module with approval), use:
+
+```bash
+git commit --no-verify -m "chore: remove deprecated module (approved in PR #XX)"
+```
+
+Always document the reason in the commit message and link the PR.
+
+---
+
+## Emergency Rollback Procedures
+
+### Scenario 1: Bad commit pushed to `master` (before CI runs)
+
+```bash
+# 1. Identify the last good commit
+git log --oneline origin/master
+
+# 2. Create a revert PR (NEVER force-push to master)
+git checkout -b fix/revert-bad-commit
+git revert <bad-commit-sha>
+git push origin fix/revert-bad-commit
+
+# 3. Open PR immediately and request emergency review
+gh pr create --title "fix: revert <bad-commit-sha>" --base master
+```
+
+### Scenario 2: Files accidentally deleted — restore from last good commit
+
+```bash
+# Restore specific files/directories
+git checkout <last-good-sha> -- DECISIONS/ SPEC/ OUTPUTS/ PLAN/
+
+# Stage and commit the restore
+git add .
+git commit -m "fix: restore accidentally deleted directories from <last-good-sha>"
+```
+
+### Scenario 3: Mass-deletion detected by GitHub Actions
+
+The `mass-deletion-guard.yml` workflow will:
+1. Fail the CI check.
+2. Automatically create a GitHub issue tagging `@DevXoje`.
+3. Block the PR from being merged (if branch protection is enabled).
+
+Respond to the issue and either close the PR or provide justification for the deletion.
+
+---
+
+## Contact Points
+
+| Role | Name | GitHub |
+|------|------|--------|
+| Developer / Maintainer | Jose Vilches Sánchez | @DevXoje |
+| Academic Tutor | ANDRES MARTOS GAZQUEZ | — |
+
+For security-related issues, see `SECURITY/ci-secret-notes.md`.
+
+For project planning and sprint details, see `PLAN/backlog.md`.
+
+---
+
+*Last updated: 2026-03-29*

--- a/SECURITY/ci-secret-notes.md
+++ b/SECURITY/ci-secret-notes.md
@@ -1,0 +1,1 @@
+test file

--- a/SECURITY/ci-secret-notes.md
+++ b/SECURITY/ci-secret-notes.md
@@ -1,1 +1,94 @@
-test file
+# CI / CD Secret Management Notes
+
+> **Project**: gerocultores-system — DAW Final Project  
+> **Author**: Jose Vilches Sánchez  
+> **Tutor**: ANDRES MARTOS GAZQUEZ  
+> **Centro**: CIPFP Batoi d'Alcoi  
+> **Curso**: 2025-2026  
+>
+> ⚠️ **This file documents required secrets. It does NOT contain any secret values.**  
+> All actual secret values must be stored in GitHub repository settings under  
+> **Settings → Secrets and variables → Actions**.
+
+---
+
+## Required Secrets and Environment Variables
+
+### GitHub Actions Secrets
+
+The following secrets must be configured in the GitHub repository before running CI/CD workflows.
+Navigate to: `https://github.com/DevXoje/gerocultores-system/settings/secrets/actions`
+
+| Secret Name | Purpose | Required By | How to Get It |
+|-------------|---------|-------------|---------------|
+| `GITHUB_TOKEN` | Auto-provided by GitHub Actions — no setup needed | All workflows | Automatically injected by GitHub |
+| `FIREBASE_SERVICE_ACCOUNT` | Firebase Admin SDK authentication for CI deployments | (future) `deploy.yml` | Firebase Console → Project Settings → Service accounts → Generate new private key |
+| `FIREBASE_APP_ID` | Firebase app identifier | (future) frontend build | Firebase Console → Project Settings → General → Your apps |
+
+> **Note**: `GITHUB_TOKEN` is automatically available in all GitHub Actions workflows.
+> You do **not** need to create it manually.
+
+### Firebase (future — when stack is decided via ADR-01)
+
+When the stack decision (Firebase vs alternatives) is resolved in `DECISIONS/ADR-01-stack.md`,
+add the required secrets for the chosen platform. Until then, no Firebase secrets are needed.
+
+---
+
+## How to Add Secrets in GitHub
+
+1. Go to your repository: `https://github.com/DevXoje/gerocultores-system`
+2. Click **Settings** → **Secrets and variables** → **Actions**
+3. Click **New repository secret**
+4. Enter the secret name (e.g., `FIREBASE_SERVICE_ACCOUNT`) and paste the value
+5. Click **Add secret**
+
+---
+
+## Current Workflow Requirements
+
+### `mass-deletion-guard.yml`
+
+- **Requires**: `GITHUB_TOKEN` (auto-injected — no setup needed)
+- **Uses**: `permissions: issues: write` to create GitHub issues when mass-deletions are detected
+- **No additional secrets needed**
+
+---
+
+## Security Policy
+
+### Rules
+
+1. **Never commit secret values** to the repository — not in source code, not in `.env` files, not in documentation.
+2. **Use `.env.example`** to document required environment variable names (without values). Create it when the stack is implemented.
+3. **Rotate secrets** if they are ever accidentally exposed. Report immediately to @DevXoje.
+4. **Minimum access scope**: Request only the permissions a secret actually needs (e.g., don't use an admin key where a read-only key suffices).
+
+### What to Do If a Secret Is Exposed
+
+1. **Immediately revoke** the compromised secret in the issuing platform (Firebase Console, GitHub Settings, etc.)
+2. **Generate a new secret** and add it to GitHub Secrets
+3. **Create an incident issue** in the repository with label `security` (do NOT include the secret value in the issue)
+4. **Notify** Jose Vilches Sánchez (@DevXoje) immediately
+
+---
+
+## .env.example (placeholder — update when stack is confirmed)
+
+When the frontend/backend stack is decided, create `.env.example` at the repository root:
+
+```
+# Firebase (example — values are placeholders, not real)
+VITE_FIREBASE_API_KEY=your_api_key_here
+VITE_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=your_project_id
+VITE_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
+VITE_FIREBASE_MESSAGING_SENDER_ID=000000000000
+VITE_FIREBASE_APP_ID=1:000000000000:web:000000000000000000
+```
+
+Add `.env` and `.env.local` to `.gitignore` to prevent accidental secret commits.
+
+---
+
+*Last updated: 2026-03-29 | Maintained by @DevXoje*

--- a/TOOLS/pre-commit-template.sh
+++ b/TOOLS/pre-commit-template.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# =============================================================================
+# pre-commit-template.sh
+# gerocultores-system — Mass-Deletion Guardrail Pre-commit Hook
+# =============================================================================
+#
+# PURPOSE:
+#   Prevent accidental mass-deletion of files in a single commit.
+#   If more than 10 files are staged for deletion, this hook aborts
+#   the commit and instructs the developer to use a Pull Request instead.
+#
+# INSTALLATION (run once per local clone):
+#   cp TOOLS/pre-commit-template.sh .git/hooks/pre-commit
+#   chmod +x .git/hooks/pre-commit
+#
+# NOTE:
+#   This hook is NOT installed automatically. It is the developer's
+#   responsibility to install it. See CONTRIBUTING.md for details.
+#
+# BYPASS (use only when explicitly approved via PR):
+#   git commit --no-verify -m "chore: approved mass-deletion (PR #XX)"
+#
+# Authors: Jose Vilches Sánchez / ANDRES MARTOS GAZQUEZ
+# Repository: https://github.com/DevXoje/gerocultores-system
+# =============================================================================
+
+set -e
+
+# Threshold: abort if more than this many files are deleted in one commit
+MAX_DELETIONS=15
+
+# Count staged deletions (D = deleted in git diff --cached --name-status)
+DELETED_COUNT=$(git diff --cached --name-status | grep -c "^D" || true)
+
+if [ "$DELETED_COUNT" -gt "$MAX_DELETIONS" ]; then
+  echo ""
+  echo "╔══════════════════════════════════════════════════════════════╗"
+  echo "║          COMMIT ABORTED — MASS DELETION DETECTED            ║"
+  echo "╠══════════════════════════════════════════════════════════════╣"
+  echo "║                                                              ║"
+  echo "║  You are about to delete ${DELETED_COUNT} files in a single commit.      ║"
+  echo "║  The policy for this repository limits deletions to         ║"
+  echo "║  ${MAX_DELETIONS} files per commit to prevent accidental data loss.     ║"
+  echo "║                                                              ║"
+  echo "║  What to do instead:                                        ║"
+  echo "║  1. Create a dedicated branch for this deletion             ║"
+  echo "║  2. Push the branch to origin                               ║"
+  echo "║  3. Open a Pull Request with a clear justification          ║"
+  echo "║  4. Get a review and approval before merging                ║"
+  echo "║                                                              ║"
+  echo "║  If the deletion is intentional and approved via PR:        ║"
+  echo "║    git commit --no-verify -m 'chore: ... (PR #XX)'         ║"
+  echo "║                                                              ║"
+  echo "║  See CONTRIBUTING.md for the full Mass-Deletion Guardrail.  ║"
+  echo "╚══════════════════════════════════════════════════════════════╝"
+  echo ""
+  exit 1
+fi
+
+# Also check for deletion of top-level critical directories
+# AGENTS/ is included because it contains guardrail and role definitions
+CRITICAL_DIRS="AGENTS DECISIONS SPEC OUTPUTS PLAN"
+
+for DIR in $CRITICAL_DIRS; do
+  CRITICAL_DELETIONS=$(git diff --cached --name-status | grep "^D" | grep "^D\s*${DIR}/" | wc -l | tr -d ' ')
+  if [ "$CRITICAL_DELETIONS" -gt 0 ]; then
+    echo ""
+    echo "╔══════════════════════════════════════════════════════════════╗"
+    echo "║       COMMIT ABORTED — CRITICAL DIRECTORY DELETION          ║"
+    echo "╠══════════════════════════════════════════════════════════════╣"
+    echo "║                                                              ║"
+    echo "║  You are deleting files from the critical directory:        ║"
+    echo "║    ${DIR}/                                                   ║"
+    echo "║                                                              ║"
+    echo "║  This directory contains SDD artifacts (specs, decisions,   ║"
+    echo "║  outputs, plans) that must not be deleted without an ADR    ║"
+    echo "║  and explicit approval via Pull Request.                    ║"
+    echo "║                                                              ║"
+    echo "║  If this deletion is approved, use:                         ║"
+    echo "║    git commit --no-verify -m 'chore: ... (ADR-XX, PR #XX)' ║"
+    echo "║                                                              ║"
+    echo "║  See CONTRIBUTING.md for the full policy.                   ║"
+    echo "╚══════════════════════════════════════════════════════════════╝"
+    echo ""
+    exit 1
+  fi
+done
+
+# All checks passed
+exit 0


### PR DESCRIPTION
## Summary

- Adds **`CONTRIBUTING.md`** with full contribution policy: no direct pushes to `master`, commit conventions, mass-deletion guardrail rules, pre-commit hook setup instructions, and emergency rollback procedures. Authors: Jose Vilches Sánchez / ANDRES MARTOS GAZQUEZ.
- Adds **`CODEOWNERS`** covering critical SDD artifact directories (`DECISIONS/*`, `SPEC/*`, `OUTPUTS/*`, `PLAN/*`) → `@DevXoje`.
- Adds **`.github/PULL_REQUEST_TEMPLATE.md`** with a content safety checklist including 'No deletions of top-level dirs' and 'All modified files are intentional'.
- Adds **`TOOLS/pre-commit-template.sh`** — opt-in local hook that aborts commits deleting >10 files or touching critical directories. Not auto-installed; instructions in CONTRIBUTING.md.
- Adds **`.github/workflows/mass-deletion-guard.yml`** (pending push with `workflow` scope — see note below) — CI guard that fails on mass-deletions and auto-creates a GitHub issue tagging `@DevXoje`.

## SDD Topic Key

**topic_key**: `sdd/guardrails-improvement`

## Type of Change

- [x] `chore` — maintenance / tooling
- [x] `ci` — CI/CD pipeline change
- [x] `docs` — documentation only

## Checklist

### Content Safety
- [x] No deletions of top-level directories (`DECISIONS/`, `SPEC/`, `OUTPUTS/`, `PLAN/`)
- [x] No more than 10 files deleted
- [x] All modified files are intentional (no accidental staging)
- [x] No secrets, credentials, or tokens committed

### Code Quality
- [x] No code files changed — documentation, config and shell script only
- [x] Shell script in `TOOLS/pre-commit-template.sh` follows POSIX sh conventions

### Documentation
- [x] `CONTRIBUTING.md` is the primary documentation for this change
- [x] SDD artifact reference: `sdd/guardrails-improvement`

### Review
- [x] Self-reviewed the diff
- [x] No unintended changes

## Note on GitHub Actions Workflow

The commit `ci(guardrails): add GitHub Actions mass-deletion guard workflow` is ready locally but requires the git remote's OAuth token to have `workflow` scope to push. To complete the push:

```bash
gh auth refresh -h github.com -s workflow
git push origin guardrails/patch-1
```

Or the workflow file can be added directly to `master` via the GitHub web UI.

## Related

This PR is the first protective measure in response to a prior incident where top-level SDD artifact directories were accidentally deleted via a destructive commit.

**Next steps after merging**: Verify branch protection rules on `master` are active (require PR reviews, status checks, no force-push, no delete).

---

*Maintained by @DevXoje. See `CONTRIBUTING.md` for full policy.*