### PR TITLE
chore(style): format TaskCard and tareas.api with Prettier

### DIFF
--- a/code/frontend/src/components/TaskCard/TaskCard.spec.ts
+++ b/code/frontend/src/components/TaskCard/TaskCard.spec.ts
@@ -58,7 +58,9 @@ describe('TaskCard — render', () => {
     const tarea = makeTarea({ notas: 'Paciente colaborador' })
     const wrapper = mount(TaskCard, { props: { tarea } })
 
-    expect(wrapper.get('[data-testid="task-card-notes-tarea-001"]').text()).toBe('Paciente colaborador')
+    expect(wrapper.get('[data-testid="task-card-notes-tarea-001"]').text()).toBe(
+      'Paciente colaborador'
+    )
   })
 
   it('does not render notes element when notas is null', () => {
@@ -74,7 +76,9 @@ describe('TaskCard — render', () => {
       props: { tarea, assignedToDisplayName: 'María García' },
     })
 
-    expect(wrapper.get('[data-testid="task-card-assignee-tarea-001"]').text()).toContain('María García')
+    expect(wrapper.get('[data-testid="task-card-assignee-tarea-001"]').text()).toContain(
+      'María García'
+    )
   })
 
   it('does not render assignee when prop is absent', () => {
@@ -88,14 +92,18 @@ describe('TaskCard — render', () => {
     const tarea = makeTarea({ estado: 'completada' })
     const wrapper = mount(TaskCard, { props: { tarea } })
 
-    expect(wrapper.get('[data-testid="task-card-title-tarea-001"]').classes()).toContain('task-card__title--done')
+    expect(wrapper.get('[data-testid="task-card-title-tarea-001"]').classes()).toContain(
+      'task-card__title--done'
+    )
   })
 
   it('does not apply line-through class when estado is pendiente', () => {
     const tarea = makeTarea({ estado: 'pendiente' })
     const wrapper = mount(TaskCard, { props: { tarea } })
 
-    expect(wrapper.get('[data-testid="task-card-title-tarea-001"]').classes()).not.toContain('task-card__title--done')
+    expect(wrapper.get('[data-testid="task-card-title-tarea-001"]').classes()).not.toContain(
+      'task-card__title--done'
+    )
   })
 
   it('has role="article" on the root element', () => {

--- a/code/frontend/src/components/TaskCard/TaskCard.vue
+++ b/code/frontend/src/components/TaskCard/TaskCard.vue
@@ -10,7 +10,11 @@
  * US-03: Consulta de agenda diaria
  * Stitch reference: Caregiver Dashboard (design-source.md)
  */
-import type { TareaResponse, TareaEstado, TareaTipo } from '@/business/agenda/domain/entities/tarea.types'
+import type {
+  TareaResponse,
+  TareaEstado,
+  TareaTipo,
+} from '@/business/agenda/domain/entities/tarea.types'
 
 // ─── Props & Emits ────────────────────────────────────────────────────────────
 
@@ -119,10 +123,7 @@ function isCompleted(estado: TareaEstado): boolean {
 
       <!-- Notes (truncated) -->
       <template v-if="tarea.notas">
-        <p
-          class="task-card__notes"
-          :data-testid="`task-card-notes-${tarea.id}`"
-        >
+        <p class="task-card__notes" :data-testid="`task-card-notes-${tarea.id}`">
           {{ tarea.notas }}
         </p>
       </template>
@@ -135,7 +136,9 @@ function isCompleted(estado: TareaEstado): boolean {
             :data-testid="`task-card-assignee-${tarea.id}`"
             :aria-label="`Asignado a: ${props.assignedToDisplayName}`"
           >
-            <span class="material-symbols-outlined task-card__assignee-icon" aria-hidden="true">person</span>
+            <span class="material-symbols-outlined task-card__assignee-icon" aria-hidden="true"
+              >person</span
+            >
             {{ props.assignedToDisplayName }}
           </span>
         </template>
@@ -144,9 +147,15 @@ function isCompleted(estado: TareaEstado): boolean {
           <!-- Toggle complete -->
           <button
             class="task-card__action-btn"
-            :class="isCompleted(tarea.estado) ? 'task-card__action-btn--undo' : 'task-card__action-btn--complete'"
+            :class="
+              isCompleted(tarea.estado)
+                ? 'task-card__action-btn--undo'
+                : 'task-card__action-btn--complete'
+            "
             type="button"
-            :aria-label="isCompleted(tarea.estado) ? 'Marcar como pendiente' : 'Marcar como completada'"
+            :aria-label="
+              isCompleted(tarea.estado) ? 'Marcar como pendiente' : 'Marcar como completada'
+            "
             :data-testid="`task-card-toggle-${tarea.id}`"
             @click.stop="emit('toggleComplete', tarea.id)"
           >
@@ -179,7 +188,9 @@ function isCompleted(estado: TareaEstado): boolean {
   @apply flex flex-row overflow-hidden rounded-xl cursor-pointer select-none;
   background-color: var(--color-surface-container-lowest);
   box-shadow: 0 1px 3px color-mix(in srgb, var(--color-on-surface) 10%, transparent);
-  transition: box-shadow 0.15s ease, transform 0.1s ease;
+  transition:
+    box-shadow 0.15s ease,
+    transform 0.1s ease;
   min-height: 44px;
 
   &:hover {
@@ -295,7 +306,9 @@ function isCompleted(estado: TareaEstado): boolean {
   @apply flex items-center justify-center w-11 h-11 rounded-full border-none cursor-pointer;
   background-color: transparent;
   color: var(--color-on-surface-variant);
-  transition: background-color 0.15s ease, color 0.15s ease;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
 
   &:hover {
     background-color: var(--color-surface-container-high);

--- a/code/frontend/src/services/tareas.api.ts
+++ b/code/frontend/src/services/tareas.api.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from 'axios'
 
 // API Client configuration
 // US-03: Consulta de agenda diaria
@@ -10,65 +10,71 @@ const apiClient = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-});
+})
 
 // Assuming a token injection interceptor exists elsewhere, e.g.:
 // apiClient.interceptors.request.use((config) => { ... inject Firebase ID token ... })
 
 // Types based on the Tarea entity
-export type TipoTarea = 'higiene' | 'medicacion' | 'alimentacion' | 'actividad' | 'revision' | 'otro';
-export type EstadoTarea = 'pendiente' | 'en_curso' | 'completada' | 'con_incidencia';
+export type TipoTarea =
+  | 'higiene'
+  | 'medicacion'
+  | 'alimentacion'
+  | 'actividad'
+  | 'revision'
+  | 'otro'
+export type EstadoTarea = 'pendiente' | 'en_curso' | 'completada' | 'con_incidencia'
 
 export interface TareaDTO {
-  id: string;
-  titulo: string;
-  tipo: TipoTarea;
-  fechaHora: string; // ISO8601 string
-  estado: EstadoTarea;
-  notas: string | null;
-  residenteId: string;
-  usuarioId: string;
-  creadoEn: string;
-  actualizadoEn: string;
-  completadaEn: string | null;
+  id: string
+  titulo: string
+  tipo: TipoTarea
+  fechaHora: string // ISO8601 string
+  estado: EstadoTarea
+  notas: string | null
+  residenteId: string
+  usuarioId: string
+  creadoEn: string
+  actualizadoEn: string
+  completadaEn: string | null
 }
 
 export interface ListTareasParams {
-  date?: string; // YYYY-MM-DD
-  assignedTo?: string; // uid
-  status?: EstadoTarea;
+  date?: string // YYYY-MM-DD
+  assignedTo?: string // uid
+  status?: EstadoTarea
 }
 
 export interface CreateTareaDTO {
-  titulo: string;
-  tipo: TipoTarea;
-  fechaHora: string;
-  residenteId: string;
-  usuarioId: string;
-  notas?: string;
+  titulo: string
+  tipo: TipoTarea
+  fechaHora: string
+  residenteId: string
+  usuarioId: string
+  notas?: string
 }
 
 export interface UpdateTareaStatusDTO {
-  estado: EstadoTarea;
+  estado: EstadoTarea
 }
 
 export interface UpdateTareaDTO {
-  titulo?: string;
-  tipo?: TipoTarea;
-  fechaHora?: string;
-  residenteId?: string;
-  usuarioId?: string;
-  notas?: string;
+  titulo?: string
+  tipo?: TipoTarea
+  fechaHora?: string
+  residenteId?: string
+  usuarioId?: string
+  notas?: string
 }
 
 export interface AddTareaNotesDTO {
-  notas: string;
+  notas: string
 }
 
 export interface ApiResponse<T> {
-  data: T;
+  data: T
   // `unknown` used instead of `any`: meta is an opaque server bag; callers must narrow before use.
-  meta?: Record<string, unknown>;
+  meta?: Record<string, unknown>
 }
 
 // Tareas Service
@@ -77,47 +83,47 @@ export const tareasApi = {
    * Retrieves a list of tasks, optionally filtered.
    */
   async getTareas(params?: ListTareasParams): Promise<ApiResponse<TareaDTO[]>> {
-    const response = await apiClient.get<ApiResponse<TareaDTO[]>>('/tareas', { params });
-    return response.data;
+    const response = await apiClient.get<ApiResponse<TareaDTO[]>>('/tareas', { params })
+    return response.data
   },
 
   /**
    * Retrieves a single task by ID.
    */
   async getTarea(id: string): Promise<ApiResponse<TareaDTO>> {
-    const response = await apiClient.get<ApiResponse<TareaDTO>>(`/tareas/${id}`);
-    return response.data;
+    const response = await apiClient.get<ApiResponse<TareaDTO>>(`/tareas/${id}`)
+    return response.data
   },
 
   /**
    * Creates a new task.
    */
   async createTarea(data: CreateTareaDTO): Promise<ApiResponse<TareaDTO>> {
-    const response = await apiClient.post<ApiResponse<TareaDTO>>('/tareas', data);
-    return response.data;
+    const response = await apiClient.post<ApiResponse<TareaDTO>>('/tareas', data)
+    return response.data
   },
 
   /**
    * Updates only the status of a specific task.
    */
   async updateTareaStatus(id: string, data: UpdateTareaStatusDTO): Promise<ApiResponse<TareaDTO>> {
-    const response = await apiClient.patch<ApiResponse<TareaDTO>>(`/tareas/${id}/status`, data);
-    return response.data;
+    const response = await apiClient.patch<ApiResponse<TareaDTO>>(`/tareas/${id}/status`, data)
+    return response.data
   },
 
   /**
    * Partially updates task fields.
    */
   async updateTarea(id: string, data: UpdateTareaDTO): Promise<ApiResponse<TareaDTO>> {
-    const response = await apiClient.patch<ApiResponse<TareaDTO>>(`/tareas/${id}`, data);
-    return response.data;
+    const response = await apiClient.patch<ApiResponse<TareaDTO>>(`/tareas/${id}`, data)
+    return response.data
   },
 
   /**
    * Appends or updates notes for a task.
    */
   async addTareaNotes(id: string, data: AddTareaNotesDTO): Promise<ApiResponse<TareaDTO>> {
-    const response = await apiClient.post<ApiResponse<TareaDTO>>(`/tareas/${id}/notes`, data);
-    return response.data;
-  }
-};
+    const response = await apiClient.post<ApiResponse<TareaDTO>>(`/tareas/${id}/notes`, data)
+    return response.data
+  },
+}


### PR DESCRIPTION
## Summary

Applied `prettier --write` to fix CI format check failures blocking the deploy pipeline.

### Why

CI workflow runs 24611126361 and 24611126362 failed on the `format:check` step because the following files did not conform to the project's Prettier configuration. This PR applies only formatting changes to unblock the pipeline.

### Files Changed

- `code/frontend/src/components/TaskCard/TaskCard.spec.ts` — Prettier formatting applied
- `code/frontend/src/components/TaskCard/TaskCard.vue` — Prettier formatting applied
- `code/frontend/src/services/tareas.api.ts` — Prettier formatting applied

### Checks Run Locally

- ✅ `npm --prefix code/frontend run format:check` — All matched files use Prettier code style!
- ✅ `npm --prefix code/frontend run lint` — No ESLint errors
- ✅ `npx tsc --noEmit` — No TypeScript errors
- ✅ `npm --prefix code/frontend test -- --run` — 5 test files, 59 tests, all passed

### Scope

**Minimal diff**: only whitespace/formatting changes on the 3 specified files. No logic changes, no `package.json` or lockfile changes.

Please merge to unblock the deploy pipeline.

Ref: CI failures 24611126361, 24611126362