### PR TITLE
test: update legacy role in tests (coordinador -> gerocultor/admin)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,3 @@
 #!/bin/sh
 # pre-push: run test suite before pushing
-# Note: npm test runs frontend + api tests.
-# Two API tests are pre-existing failures (coordinador role, tracked in tech debt).
-# The hook runs the full suite; CI is authoritative for blocking.
 npm --prefix code/frontend run test

--- a/code/api/src/middleware/requireRole.spec.ts
+++ b/code/api/src/middleware/requireRole.spec.ts
@@ -15,7 +15,7 @@ function makeReq(userRole?: string | undefined): Partial<Request> {
     return {}
   }
   return {
-    user: { role: userRole } as unknown as Request['user'],
+    user: { rol: userRole } as unknown as Request['user'],
   }
 }
 
@@ -36,7 +36,7 @@ describe('requireRole middleware factory', () => {
 
   // ── Passing cases ──────────────────────────────────────────────────────────
 
-  it('calls next() when requireRole("admin") and user.role === "admin"', () => {
+  it('calls next() when requireRole("admin") and user.rol === "admin"', () => {
     const req = makeReq('admin')
     const { status } = makeRes()
 
@@ -46,7 +46,7 @@ describe('requireRole middleware factory', () => {
     expect(status).not.toHaveBeenCalled()
   })
 
-  it('calls next() when requireRole("gerocultor") and user.role === "gerocultor"', () => {
+  it('calls next() when requireRole("gerocultor") and user.rol === "gerocultor"', () => {
     const req = makeReq('gerocultor')
     const { status } = makeRes()
 
@@ -76,7 +76,7 @@ describe('requireRole middleware factory', () => {
 
   // ── Failing cases — 403 ────────────────────────────────────────────────────
 
-  it('returns 403 when requireRole("admin") and user.role === "gerocultor"', () => {
+  it('returns 403 when requireRole("admin") and user.rol === "gerocultor"', () => {
     const req = makeReq('gerocultor')
     const { status, json } = makeRes()
 
@@ -102,7 +102,7 @@ describe('requireRole middleware factory', () => {
     )
   })
 
-  it('returns 403 when requireRole("admin") and user.role is an unknown value', () => {
+  it('returns 403 when requireRole("admin") and user.rol is an unknown value', () => {
     const req = makeReq('superuser') // not a valid UserRole
     const { status, json } = makeRes()
 

--- a/code/api/src/middleware/requireRole.ts
+++ b/code/api/src/middleware/requireRole.ts
@@ -10,7 +10,7 @@ type UserRole = 'admin' | 'gerocultor'
  */
 export function requireRole(...roles: string[]): RequestHandler {
   return (req: Request, res: Response, next: NextFunction): void => {
-    const userRole = req.user?.['role'] as UserRole | undefined
+    const userRole = req.user?.['rol'] as UserRole | undefined
 
     if (!userRole || !roles.includes(userRole)) {
       res.status(403).json({ error: 'Acceso no autorizado', code: 'FORBIDDEN' })

--- a/code/api/src/middleware/verifyAuth.spec.ts
+++ b/code/api/src/middleware/verifyAuth.spec.ts
@@ -75,7 +75,7 @@ describe('requireRole factory', () => {
     vi.clearAllMocks()
   })
 
-  it('should return 403 when user has role "gerocultor" and requireRole("coordinador") is applied', async () => {
+  it('should return 403 when user has role "gerocultor" and requireRole("admin") is applied', async () => {
     const fakeDecoded = {
       uid: 'uid-gerocultor-01',
       email: 'gerocultor@example.com',
@@ -84,22 +84,22 @@ describe('requireRole factory', () => {
     mockVerifyIdToken.mockResolvedValueOnce(fakeDecoded as never)
 
     const res = await request(app)
-      .get('/api/protected/coordinador-only')
+      .get('/api/protected/admin-only')
       .set('Authorization', 'Bearer valid-token')
     expect(res.status).toBe(403)
     expect(res.body).toMatchObject({ error: expect.any(String) })
   })
 
-  it('should call next() when user has role "coordinador" and requireRole("coordinador") is applied', async () => {
+  it('should call next() when user has role "admin" and requireRole("admin") is applied', async () => {
     const fakeDecoded = {
-      uid: 'uid-coordinador-01',
-      email: 'coordinador@example.com',
-      rol: 'coordinador',
+      uid: 'uid-admin-01',
+      email: 'admin@example.com',
+      rol: 'admin',
     }
     mockVerifyIdToken.mockResolvedValueOnce(fakeDecoded as never)
 
     const res = await request(app)
-      .get('/api/protected/coordinador-only')
+      .get('/api/protected/admin-only')
       .set('Authorization', 'Bearer valid-token')
     expect(res.status).toBe(200)
   })

--- a/code/api/src/routes/index.ts
+++ b/code/api/src/routes/index.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express'
 import { verifyAuth } from '../middleware/verifyAuth'
+import { requireRole } from '../middleware/requireRole'
 import adminUsersRouter from './admin.users.routes'
 
 const router = Router()
@@ -19,6 +20,10 @@ protectedRouter.get('/', (_req, res) => {
   res.json({ status: 'authenticated' })
 })
 
+// Admin-only route — requires admin role
+protectedRouter.get('/admin-only', requireRole('admin'), (_req, res) => {
+  res.json({ status: 'admin-authorized' })
+})
 
 router.use('/api/protected', protectedRouter)
 router.use('/api/admin/users', adminUsersRouter)


### PR DESCRIPTION
## Executive Summary

Fixes 2 pre-existing CI failures caused by test code referencing a legacy role (`coordinador`) and a route (`/api/protected/coordinador-only`) that no longer exist in the canonical project model. The canonical roles are `admin` and `gerocultor` per `AGENTS.md`/`SPEC/entities.md`. All 34 API tests and 59 frontend tests now pass.

## Files Changed

| File | Change |
|------|--------|
| `code/api/src/middleware/verifyAuth.spec.ts` | Replaced `coordinador` role fixtures with `admin`; updated test route from `/coordinador-only` to `/admin-only` |
| `code/api/src/middleware/requireRole.spec.ts` | Fixed test fixtures to use `rol` (correct Firebase custom claim field) instead of `role` |
| `code/api/src/middleware/requireRole.ts` | **Minimal source fix**: corrected `req.user['role']` → `req.user['rol']` to match `DecodedIdToken` custom claim key |
| `code/api/src/routes/index.ts` | Added `/api/protected/admin-only` route required by requireRole tests |
| `.husky/pre-push` | Removed stale tech-debt comment about coordinador failures (now resolved) |

## Test Results

### Before
```
Tests  2 failed | 32 passed (34)   [verifyAuth.spec.ts — 404 vs expected 403/200]
```

### After
```
Test Files  4 passed (4)
     Tests  34 passed (34)          [API — all green]

Test Files  5 passed (5)
     Tests  59 passed (59)          [Frontend — all green]
```

## Source Code Findings (Non-test `coordinador` occurrences)

The following production files reference `coordinador` as a third role. These are **NOT changed** in this PR — they reflect the broader role model in SPEC/ which predates the canonical 2-role simplification in `AGENTS.md`. These require a separate intentional decision:

- `code/firestore.rules` — uses `coordinador` and `administrador` roles in security rules
- `AGENTS/backend-specialist.md` — documents `coordinador` as a valid custom claim value
- `DECISIONS/ADR-03b-authentication-firebase.md` — ADR describes 3-role model
- Various `SPEC/`, `OUTPUTS/academic/`, `PLAN/` files — documentation references

**Recommended next steps for source files**: Open a separate issue to align `firestore.rules` and `ADR-03b` with the 2-role model (`admin` + `gerocultor`) if that simplification is confirmed.

## Related SPEC Notes

The AGENTS.md (§GGA Review Context) states: _"This project has exactly two roles: 'admin' and 'gerocultor'. Any reference to coordinador, administrador, or any other role is a G04/G06 violation."_ This PR brings the automated tests into compliance.

## Remaining Failing Tests

None — all tests pass after this fix.

---

Resolves: legacy role `coordinador` in test suite (tracked in `.husky/pre-push` tech-debt comment)