### PR TITLE
feat(US-03): add tareas API with Firestore transaction for concurrent estado updates (DT-06)

### DIFF
--- a/code/api/src/controllers/tareas.controller.ts
+++ b/code/api/src/controllers/tareas.controller.ts
@@ -1,0 +1,90 @@
+import type { Request, Response, NextFunction } from 'express'
+import { TareasService, NotFoundError, ForbiddenError } from '../services/tareas.service'
+import { UpdateEstadoSchema, ListTareasQuerySchema } from '../types/tarea.types'
+import type { UserRole } from '../types/user.types'
+
+export class TareasController {
+  private service = new TareasService()
+
+  listTareas = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const parsed = ListTareasQuerySchema.safeParse(req.query)
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Parámetros inválidos',
+          code: 'VALIDATION_ERROR',
+          details: parsed.error.flatten().fieldErrors,
+        })
+        return
+      }
+
+      const filters = parsed.data
+      const userRole = req.user?.['role'] as UserRole
+      const userUid = req.user?.uid as string
+
+      // gerocultor can only see their own tasks
+      if (userRole === 'gerocultor') {
+        filters.assignedTo = userUid
+      }
+
+      const tareas = await this.service.getTareas(filters)
+      res.json({ data: tareas, meta: { total: tareas.length } })
+    } catch (e) {
+      next(e)
+    }
+  }
+
+  getTarea = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const id = req.params['id'] as string
+      const tarea = await this.service.getTareaById(id)
+
+      const userRole = req.user?.['role'] as UserRole
+      const userUid = req.user?.uid as string
+
+      if (userRole === 'gerocultor' && tarea.usuarioId !== userUid) {
+        res.status(403).json({ error: 'Acceso no autorizado', code: 'FORBIDDEN' })
+        return
+      }
+
+      res.json({ data: tarea })
+    } catch (e) {
+      if (e instanceof NotFoundError) {
+        res.status(404).json({ error: e.message, code: 'NOT_FOUND' })
+        return
+      }
+      next(e)
+    }
+  }
+
+  patchEstado = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const id = req.params['id'] as string
+      const parsed = UpdateEstadoSchema.safeParse(req.body)
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Datos inválidos',
+          code: 'VALIDATION_ERROR',
+          details: parsed.error.flatten().fieldErrors,
+        })
+        return
+      }
+
+      const userRole = req.user?.['role'] as UserRole
+      const userUid = req.user?.uid as string
+
+      const updated = await this.service.updateEstado(id, parsed.data.estado, userUid, userRole)
+      res.json({ data: updated })
+    } catch (e) {
+      if (e instanceof NotFoundError) {
+        res.status(404).json({ error: e.message, code: 'NOT_FOUND' })
+        return
+      }
+      if (e instanceof ForbiddenError) {
+        res.status(403).json({ error: e.message, code: 'FORBIDDEN' })
+        return
+      }
+      next(e)
+    }
+  }
+}

--- a/code/api/src/routes/index.ts
+++ b/code/api/src/routes/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import { verifyAuth } from '../middleware/verifyAuth'
 import adminUsersRouter from './admin.users.routes'
+import tareasRouter from './tareas.routes'
 
 const router = Router()
 
@@ -22,5 +23,6 @@ protectedRouter.get('/', (_req, res) => {
 
 router.use('/api/protected', protectedRouter)
 router.use('/api/admin/users', adminUsersRouter)
+router.use('/api/tareas', tareasRouter)
 
 export default router

--- a/code/api/src/routes/tareas.routes.ts
+++ b/code/api/src/routes/tareas.routes.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express'
+import { verifyAuth } from '../middleware/verifyAuth'
+import { TareasController } from '../controllers/tareas.controller'
+
+const router = Router()
+const controller = new TareasController()
+
+// All tareas routes require authentication
+router.use(verifyAuth)
+
+// Both roles can access these routes; authorization logic is in the controller/service
+router.get('/', controller.listTareas)
+router.get('/:id', controller.getTarea)
+router.patch('/:id/estado', controller.patchEstado)
+
+export default router

--- a/code/api/src/services/tareas.service.spec.ts
+++ b/code/api/src/services/tareas.service.spec.ts
@@ -1,0 +1,221 @@
+/**
+ * tareas.service.spec.ts — Unit tests for TareasService.
+ *
+ * Firestore is fully mocked — no real Firebase calls happen.
+ *
+ * US-03: Consulta de agenda diaria
+ * US-04: Actualizar estado de una tarea
+ */
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+// ─── Mock Firebase before any imports ────────────────────────────────────────
+// NOTE: vi.mock is hoisted, so the factory must not reference top-level variables.
+// We use vi.fn() directly inside the factory to avoid ReferenceError.
+
+vi.mock('../services/firebase', () => {
+  const mockTx = {
+    get: vi.fn(),
+    update: vi.fn(),
+  }
+
+  const mockDocRef = {
+    get: vi.fn(),
+  }
+
+  const mockCollectionRef = {
+    doc: vi.fn(() => mockDocRef),
+    where: vi.fn(),
+    get: vi.fn(),
+  }
+  mockCollectionRef.where.mockReturnValue(mockCollectionRef)
+
+  const mockRunTransaction = vi.fn(async (cb: (tx: typeof mockTx) => Promise<void>) => {
+    await cb(mockTx)
+  })
+
+  return {
+    adminAuth: {},
+    adminDb: {
+      collection: vi.fn(() => mockCollectionRef),
+      runTransaction: mockRunTransaction,
+      _mockTx: mockTx,
+      _mockDocRef: mockDocRef,
+      _mockCollectionRef: mockCollectionRef,
+      _mockRunTransaction: mockRunTransaction,
+    },
+  }
+})
+
+import { TareasService, NotFoundError, ForbiddenError } from './tareas.service'
+import { adminDb } from './firebase'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const sampleTareaData = {
+  titulo: 'Administrar medicación',
+  tipo: 'medicacion',
+  fechaHora: '2026-04-18T08:00:00Z',
+  estado: 'pendiente',
+  notas: null,
+  residenteId: 'res-uuid-456',
+  usuarioId: 'user-uid-123',
+  creadoEn: '2026-04-17T10:00:00Z',
+  actualizadoEn: '2026-04-17T10:00:00Z',
+  completadaEn: null,
+}
+
+const tareaId = 'tarea-uuid-001'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getMocks() {
+  const db = adminDb as unknown as {
+    _mockTx: { get: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> }
+    _mockDocRef: { get: ReturnType<typeof vi.fn> }
+    _mockCollectionRef: {
+      doc: ReturnType<typeof vi.fn>
+      where: ReturnType<typeof vi.fn>
+      get: ReturnType<typeof vi.fn>
+    }
+    _mockRunTransaction: ReturnType<typeof vi.fn>
+  }
+  return {
+    tx: db._mockTx,
+    docRef: db._mockDocRef,
+    collectionRef: db._mockCollectionRef,
+    runTransaction: db._mockRunTransaction,
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('TareasService.updateEstado', () => {
+  let service: TareasService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = new TareasService()
+    const { collectionRef, docRef } = getMocks()
+    collectionRef.doc.mockReturnValue(docRef)
+    collectionRef.where.mockReturnValue(collectionRef)
+  })
+
+  it('successfully updates estado when admin calls updateEstado', async () => {
+    const { tx, docRef } = getMocks()
+
+    const snapInTx = { exists: true, data: () => ({ ...sampleTareaData, usuarioId: 'user-uid-123' }) }
+    tx.get.mockResolvedValueOnce(snapInTx)
+
+    const snapAfter = {
+      exists: true,
+      id: tareaId,
+      data: () => ({ ...sampleTareaData, estado: 'en_curso', actualizadoEn: '2026-04-18T09:00:00Z' }),
+    }
+    docRef.get.mockResolvedValueOnce(snapAfter)
+
+    const result = await service.updateEstado(tareaId, 'en_curso', 'admin-uid', 'admin')
+
+    expect(getMocks().runTransaction).toHaveBeenCalledOnce()
+    expect(tx.update).toHaveBeenCalledOnce()
+    expect(result.id).toBe(tareaId)
+  })
+
+  it('successfully updates estado when gerocultor updates their own task', async () => {
+    const ownUid = 'user-uid-123'
+    const { tx, docRef } = getMocks()
+
+    const snapInTx = { exists: true, data: () => ({ ...sampleTareaData, usuarioId: ownUid }) }
+    tx.get.mockResolvedValueOnce(snapInTx)
+
+    const snapAfter = {
+      exists: true,
+      id: tareaId,
+      data: () => ({ ...sampleTareaData, estado: 'completada', completadaEn: '2026-04-18T09:00:00Z' }),
+    }
+    docRef.get.mockResolvedValueOnce(snapAfter)
+
+    const result = await service.updateEstado(tareaId, 'completada', ownUid, 'gerocultor')
+
+    expect(tx.update).toHaveBeenCalledOnce()
+    const updateArg = tx.update.mock.calls[0][1] as Record<string, unknown>
+    expect(updateArg['completadaEn']).toBeDefined()
+    expect(result.id).toBe(tareaId)
+  })
+
+  it('throws NotFoundError when task does not exist', async () => {
+    const { tx } = getMocks()
+
+    const snapInTx = { exists: false, data: () => null }
+    tx.get.mockResolvedValueOnce(snapInTx)
+
+    await expect(
+      service.updateEstado(tareaId, 'en_curso', 'any-uid', 'admin'),
+    ).rejects.toThrow(NotFoundError)
+  })
+
+  it('throws ForbiddenError when gerocultor tries to update another user task', async () => {
+    const { tx } = getMocks()
+
+    const snapInTx = { exists: true, data: () => ({ ...sampleTareaData, usuarioId: 'other-uid' }) }
+    tx.get.mockResolvedValueOnce(snapInTx)
+
+    await expect(
+      service.updateEstado(tareaId, 'en_curso', 'requesting-uid', 'gerocultor'),
+    ).rejects.toThrow(ForbiddenError)
+
+    expect(tx.update).not.toHaveBeenCalled()
+  })
+
+  it('sets completadaEn only when estado is completada', async () => {
+    const ownUid = 'user-uid-123'
+    const { tx, docRef } = getMocks()
+
+    const snapInTx = { exists: true, data: () => ({ ...sampleTareaData, usuarioId: ownUid }) }
+    tx.get.mockResolvedValueOnce(snapInTx)
+
+    const snapAfter = {
+      exists: true,
+      id: tareaId,
+      data: () => ({ ...sampleTareaData, estado: 'en_curso' }),
+    }
+    docRef.get.mockResolvedValueOnce(snapAfter)
+
+    await service.updateEstado(tareaId, 'en_curso', ownUid, 'gerocultor')
+
+    const updateArg = tx.update.mock.calls[0][1] as Record<string, unknown>
+    expect(updateArg['completadaEn']).toBeUndefined()
+    expect(updateArg['estado']).toBe('en_curso')
+    expect(updateArg['actualizadoEn']).toBeDefined()
+  })
+})
+
+describe('TareasService.getTareaById', () => {
+  let service: TareasService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = new TareasService()
+    const { collectionRef, docRef } = getMocks()
+    collectionRef.doc.mockReturnValue(docRef)
+  })
+
+  it('returns tarea when it exists', async () => {
+    const { docRef } = getMocks()
+    docRef.get.mockResolvedValueOnce({
+      exists: true,
+      id: tareaId,
+      data: () => sampleTareaData,
+    })
+
+    const result = await service.getTareaById(tareaId)
+    expect(result.id).toBe(tareaId)
+    expect(result.titulo).toBe(sampleTareaData.titulo)
+  })
+
+  it('throws NotFoundError when tarea does not exist', async () => {
+    const { docRef } = getMocks()
+    docRef.get.mockResolvedValueOnce({ exists: false, data: () => null })
+
+    await expect(service.getTareaById('non-existent')).rejects.toThrow(NotFoundError)
+  })
+})

--- a/code/api/src/services/tareas.service.ts
+++ b/code/api/src/services/tareas.service.ts
@@ -1,0 +1,98 @@
+import { adminDb } from './firebase'
+import { COLLECTIONS } from './collections'
+import type { TareaDoc, TareaEstado, TareaResponse, ListTareasQuery } from '../types/tarea.types'
+import type { UserRole } from '../types/user.types'
+
+export class NotFoundError extends Error {
+  readonly statusCode = 404
+  constructor(message: string) {
+    super(message)
+    this.name = 'NotFoundError'
+  }
+}
+
+export class ForbiddenError extends Error {
+  readonly statusCode = 403
+  constructor(message: string) {
+    super(message)
+    this.name = 'ForbiddenError'
+  }
+}
+
+function docToResponse(id: string, data: FirebaseFirestore.DocumentData): TareaResponse {
+  return {
+    id,
+    titulo: data['titulo'] as string,
+    tipo: data['tipo'],
+    fechaHora: data['fechaHora'] as string,
+    estado: data['estado'],
+    notas: (data['notas'] as string | null) ?? null,
+    residenteId: data['residenteId'] as string,
+    usuarioId: data['usuarioId'] as string,
+    creadoEn: data['creadoEn'] as string,
+    actualizadoEn: data['actualizadoEn'] as string,
+    completadaEn: (data['completadaEn'] as string | null) ?? null,
+  }
+}
+
+export class TareasService {
+  private get collection() {
+    return adminDb.collection(COLLECTIONS.tareas)
+  }
+
+  async getTareas(filters: ListTareasQuery): Promise<TareaResponse[]> {
+    let query: FirebaseFirestore.Query = this.collection
+
+    if (filters.assignedTo) {
+      query = query.where('usuarioId', '==', filters.assignedTo)
+    }
+    if (filters.status) {
+      query = query.where('estado', '==', filters.status)
+    }
+
+    const snapshot = await query.get()
+    let docs = snapshot.docs.map((doc) => docToResponse(doc.id, doc.data()))
+
+    if (filters.date) {
+      docs = docs.filter((t) => t.fechaHora.startsWith(filters.date as string))
+    }
+
+    return docs
+  }
+
+  async getTareaById(id: string): Promise<TareaResponse> {
+    const snap = await this.collection.doc(id).get()
+    if (!snap.exists) throw new NotFoundError('Tarea not found')
+    return docToResponse(snap.id, snap.data()!)
+  }
+
+  async updateEstado(
+    id: string,
+    estado: TareaEstado,
+    requestingUid: string,
+    requestingRole: UserRole,
+  ): Promise<TareaResponse> {
+    await adminDb.runTransaction(async (tx) => {
+      const ref = adminDb.collection(COLLECTIONS.tareas).doc(id)
+      const snap = await tx.get(ref)
+
+      if (!snap.exists) throw new NotFoundError('Tarea not found')
+
+      if (requestingRole === 'gerocultor' && snap.data()!['usuarioId'] !== requestingUid) {
+        throw new ForbiddenError("Cannot update another user's task")
+      }
+
+      const updates: Partial<TareaDoc> = {
+        estado,
+        actualizadoEn: new Date().toISOString(),
+      }
+      if (estado === 'completada') {
+        updates.completadaEn = new Date().toISOString()
+      }
+
+      tx.update(ref, updates as FirebaseFirestore.UpdateData<TareaDoc>)
+    })
+
+    return this.getTareaById(id)
+  }
+}

--- a/code/api/src/types/tarea.types.ts
+++ b/code/api/src/types/tarea.types.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod'
+
+export const TareaTipoEnum = z.enum([
+  'higiene',
+  'medicacion',
+  'alimentacion',
+  'actividad',
+  'revision',
+  'otro',
+])
+export type TareaTipo = z.infer<typeof TareaTipoEnum>
+
+export const TareaEstadoEnum = z.enum([
+  'pendiente',
+  'en_curso',
+  'completada',
+  'con_incidencia',
+])
+export type TareaEstado = z.infer<typeof TareaEstadoEnum>
+
+/** Shape of a Tarea document in Firestore. Field names match SPEC/entities.md exactly (G04). */
+export interface TareaDoc {
+  titulo: string
+  tipo: TareaTipo
+  fechaHora: string
+  estado: TareaEstado
+  notas: string | null
+  residenteId: string
+  usuarioId: string
+  creadoEn: string
+  actualizadoEn: string
+  completadaEn: string | null
+}
+
+/** API response shape — includes the document id. */
+export interface TareaResponse extends TareaDoc {
+  id: string
+}
+
+export const UpdateEstadoSchema = z.object({
+  estado: TareaEstadoEnum,
+})
+export type UpdateEstadoDTO = z.infer<typeof UpdateEstadoSchema>
+
+export const ListTareasQuerySchema = z.object({
+  date: z.string().optional(),
+  assignedTo: z.string().optional(),
+  status: TareaEstadoEnum.optional(),
+})
+export type ListTareasQuery = z.infer<typeof ListTareasQuerySchema>


### PR DESCRIPTION
## Summary

- Implements full `tareas` backend module: types, service, controller, and routes
- PATCH `/api/tareas/:id/estado` uses a Firestore server-side transaction to prevent concurrent update races
- Role-based authorization: `gerocultor` can only update their own tasks; `admin` can update any

## Files Created

| File | Description |
|------|-------------|
| `src/types/tarea.types.ts` | Zod schemas + TypeScript types (TareaTipo, TareaEstado, TareaDoc, TareaResponse, UpdateEstadoDTO) |
| `src/services/tareas.service.ts` | Business logic with Firestore transaction in `updateEstado` |
| `src/services/tareas.service.spec.ts` | 7 unit tests covering transaction success, 404, and 403 cases |
| `src/controllers/tareas.controller.ts` | HTTP layer: listTareas, getTarea, patchEstado |
| `src/routes/tareas.routes.ts` | Router with verifyAuth applied to all routes |

## Modified Files

- `src/routes/index.ts` — registers `/api/tareas` router

## Tests

- **7 new tests** in `tareas.service.spec.ts` — all passing
- Total: 39 tests passing (2 pre-existing failures in `verifyAuth.spec.ts` reference the invalid `coordinador` role — not related to this PR)

## Guardrails

- ✅ G01: Traceable to US-03 (agenda diaria) and US-04 (actualizar estado)
- ✅ G04: Field names match `SPEC/entities.md` exactly
- ✅ G05: No hardcoded secrets
- ✅ G06: Implementation scoped to SPEC/api/contracts/tareas.md
- ✅ G08: Commit follows `feat(US-03):` convention
- ✅ Collection names from `COLLECTIONS` constant only (never hardcoded)
- ✅ Transaction is used for PATCH — no plain `update()` call

Closes DT-06