### PR TITLE
fix(auth): remove coordinador role from verifyAuth tests

### DIFF
--- a/code/api/src/middleware/requireRole.spec.ts
+++ b/code/api/src/middleware/requireRole.spec.ts
@@ -15,7 +15,7 @@ function makeReq(userRole?: string | undefined): Partial<Request> {
     return {}
   }
   return {
-    user: { role: userRole } as unknown as Request['user'],
+    user: { rol: userRole } as unknown as Request['user'],
   }
 }
 

--- a/code/api/src/middleware/requireRole.ts
+++ b/code/api/src/middleware/requireRole.ts
@@ -10,7 +10,7 @@ type UserRole = 'admin' | 'gerocultor'
  */
 export function requireRole(...roles: string[]): RequestHandler {
   return (req: Request, res: Response, next: NextFunction): void => {
-    const userRole = req.user?.['role'] as UserRole | undefined
+    const userRole = req.user?.['rol'] as UserRole | undefined
 
     if (!userRole || !roles.includes(userRole)) {
       res.status(403).json({ error: 'Acceso no autorizado', code: 'FORBIDDEN' })

--- a/code/api/src/middleware/verifyAuth.spec.ts
+++ b/code/api/src/middleware/verifyAuth.spec.ts
@@ -7,7 +7,11 @@ vi.mock('../services/firebase', () => ({
   adminAuth: {
     verifyIdToken: vi.fn(),
   },
-  adminDb: {},
+  adminDb: {
+    collection: vi.fn().mockReturnValue({
+      get: vi.fn().mockResolvedValue({ docs: [] }),
+    }),
+  },
 }))
 
 import { adminAuth } from '../services/firebase'
@@ -70,12 +74,12 @@ describe('verifyAuth middleware', () => {
   })
 })
 
-describe('requireRole factory', () => {
+describe('requireRole factory (admin role)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('should return 403 when user has role "gerocultor" and requireRole("coordinador") is applied', async () => {
+  it('should return 403 when user has role "gerocultor" and requireRole("admin") is applied', async () => {
     const fakeDecoded = {
       uid: 'uid-gerocultor-01',
       email: 'gerocultor@example.com',
@@ -84,22 +88,22 @@ describe('requireRole factory', () => {
     mockVerifyIdToken.mockResolvedValueOnce(fakeDecoded as never)
 
     const res = await request(app)
-      .get('/api/protected/coordinador-only')
+      .get('/api/admin/users')
       .set('Authorization', 'Bearer valid-token')
     expect(res.status).toBe(403)
     expect(res.body).toMatchObject({ error: expect.any(String) })
   })
 
-  it('should call next() when user has role "coordinador" and requireRole("coordinador") is applied', async () => {
+  it('should call next() when user has role "admin" and requireRole("admin") is applied', async () => {
     const fakeDecoded = {
-      uid: 'uid-coordinador-01',
-      email: 'coordinador@example.com',
-      rol: 'coordinador',
+      uid: 'uid-admin-01',
+      email: 'admin@example.com',
+      rol: 'admin',
     }
     mockVerifyIdToken.mockResolvedValueOnce(fakeDecoded as never)
 
     const res = await request(app)
-      .get('/api/protected/coordinador-only')
+      .get('/api/admin/users')
       .set('Authorization', 'Bearer valid-token')
     expect(res.status).toBe(200)
   })


### PR DESCRIPTION
Removes stale `coordinador` references from verifyAuth.spec.ts. Fixes 2 failing unit tests. Tech debt cleanup.

## Changes
- `verifyAuth.spec.ts`: replaced `coordinador` role with `admin`/`gerocultor`, updated test routes from `/api/protected/coordinador-only` to `/api/admin/users`, extended `adminDb` mock to stub `collection()`
- `requireRole.ts`: fixed field read from `role` to `rol` (Firebase custom claim field name)
- `requireRole.spec.ts`: updated mock to use `rol` field consistently with implementation

## Tests
All 41 tests pass (5 test files).