### PR TITLE
chore(ci): opt into Node.js 24 for GitHub Actions runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - develop
       - master
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ci:
     name: Lint, Type-check, Test, Build, E2E

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy-production:
     name: Build & Deploy to Production

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy-staging:
     name: Build & Deploy to Staging

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches:
       - master
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -7,6 +7,10 @@ permissions:
   checks: write
   contents: read
   pull-requests: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build_and_preview:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/firestore-rules.yml
+++ b/.github/workflows/firestore-rules.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   firestore-rules:
     name: Firestore Security Rules (Emulator)


### PR DESCRIPTION
## Summary

- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the workflow top level to all 6 workflow files
- Silences Node.js 20 deprecation warnings for `actions/checkout@v4`, `actions/cache@v4`, `actions/setup-java@v4`, and `actions/setup-node@v4`
- Proactively opts in ahead of the June 2, 2026 forced migration deadline

## Workflows Modified

- `.github/workflows/firestore-rules.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/firebase-hosting-merge.yml`
- `.github/workflows/firebase-hosting-pull-request.yml`
- `.github/workflows/deploy-staging.yml`
- `.github/workflows/deploy-production.yml`