### PR TITLE
docs(git-flow): define branch model, rulesets and sprint helper script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Full per-agent artifacts live in:
 - `AGENTS/guardrails.md` — Non-negotiable guardrails (authoritative)
 - `AGENTS/roles.md`      — Agent role definitions and scope boundaries
 - `AGENTS/contracts.md`  — I/O contracts per agent
+- `AGENTS/git-flow.md`   — Branch model, sprint lifecycle, merge strategy (authoritative)
 
 ### Project Context
 

--- a/AGENTS/git-flow.md
+++ b/AGENTS/git-flow.md
@@ -1,0 +1,167 @@
+# Git Flow — gerocultores-system
+
+> **Authoritative source for branch naming, merge strategy, and sprint workflow.**
+> All agents must follow these conventions. Violations are treated as G06 (scope lock) or G08 (commit traceability) guardrail violations.
+
+---
+
+## Branch Model
+
+```
+master          ← production. Receives code ONLY from develop via PR.
+  └── develop   ← integration branch. Receives code ONLY from sprint/* via PR.
+        └── sprint/S{N}   ← sprint integration branch. Created from develop at sprint start.
+              ├── feat/US-XX-short-description
+              ├── fix/short-description
+              └── chore/short-description
+```
+
+### Branch Types and Naming
+
+| Branch | Pattern | Created from | Merges into | Notes |
+|--------|---------|-------------|-------------|-------|
+| Production | `master` | — | — | Protected. No direct pushes. |
+| Integration | `develop` | — | `master` (release) | Protected. No direct pushes. |
+| Sprint | `sprint/S{N}` | `develop` | `develop` | One per sprint. Created at sprint start. |
+| Feature | `feat/US-{XX}-{short}` | `sprint/S{N}` | `sprint/S{N}` | One per user story task. |
+| Fix | `fix/{short}` | `sprint/S{N}` or `develop` | same source | Bug fixes. |
+| Chore | `chore/{short}` | `sprint/S{N}` or `develop` | same source | Tooling, deps, CI. |
+| Docs | `docs/{short}` | `develop` | `develop` | Academic docs, README updates. |
+| Release | `release/vX.Y.Z` | `develop` | `master` + `develop` | Optional. For hotfix-style releases. |
+
+### Naming Examples
+
+```
+sprint/S3
+feat/US-05-ficha-residente
+feat/US-06-registro-incidencias
+fix/taskcard-date-format
+chore/update-firebase-sdk
+docs/sprint-3-close-report
+```
+
+---
+
+## Merge Strategy
+
+All merges use **squash commits** (enforced by GitHub rulesets).
+
+| Target | Source | Method | CI Required |
+|--------|--------|--------|-------------|
+| `master` | `develop` | Squash via PR | ✅ All checks must pass + 1 approval |
+| `develop` | `sprint/S{N}` | Squash via PR | ✅ All checks must pass |
+| `sprint/S{N}` | `feat/*`, `fix/*`, `chore/*` | Squash via PR | — (recommended) |
+
+> **Why squash?** Keeps `master` and `develop` history clean — one commit per sprint or feature. Full history lives in the feature branches.
+
+---
+
+## Sprint Lifecycle
+
+### 1. Start a sprint
+
+```bash
+# From the repo root — or use scripts/create-sprint.sh
+git checkout develop
+git pull origin develop
+git checkout -b sprint/S{N}
+git push -u origin sprint/S{N}
+```
+
+### 2. Work on a task
+
+```bash
+git checkout sprint/S{N}
+git pull origin sprint/S{N}
+git checkout -b feat/US-XX-short-description
+# ... develop ...
+git push -u origin feat/US-XX-short-description
+# Open PR: feat/US-XX → sprint/S{N}
+```
+
+### 3. Close a sprint
+
+1. Ensure all task PRs are merged into `sprint/S{N}`
+2. Open PR: `sprint/S{N}` → `develop`
+3. PR title: `sprint(S{N}): close sprint S{N} — US-XX, US-XX, ...`
+4. CI must pass on the PR
+5. Write sprint close report: `OUTPUTS/reports/sprint-{N}-close-report.md`
+6. Merge (squash)
+7. Delete `sprint/S{N}` branch
+
+### 4. Release to production
+
+1. Open PR: `develop` → `master`
+2. PR title: `release: vX.Y.Z — Sprint S{N}`
+3. CI must pass + 1 approval required
+4. Merge (squash)
+5. Tag: `git tag vX.Y.Z && git push origin vX.Y.Z`
+
+---
+
+## GitHub Branch Protection Summary
+
+### `master` — Protección Producción (ruleset ID: 14951374)
+
+| Rule | Value |
+|------|-------|
+| No deletion | ✅ |
+| No force push | ✅ |
+| Require PR | ✅ |
+| Required approvals | 1 |
+| Dismiss stale reviews on push | ✅ |
+| Resolve all threads before merge | ✅ |
+| Allowed merge methods | Squash only |
+| Required status checks | `CI / api-test`, `CI / frontend-test`, `CI / frontend-type-check`, `CI / frontend-format-check` |
+| Strict status checks (branch up to date) | ✅ |
+
+### `develop` — Protección Desarrollo (ruleset ID: 14951445)
+
+| Rule | Value |
+|------|-------|
+| No deletion | ✅ |
+| No force push | ✅ |
+| Require PR | ✅ |
+| Required approvals | 0 (solo developer) |
+| Dismiss stale reviews on push | ✅ |
+| Resolve all threads before merge | ✅ |
+| Allowed merge methods | Squash only |
+| Required status checks | `CI / api-test`, `CI / frontend-test`, `CI / frontend-type-check`, `CI / frontend-format-check` |
+| Strict status checks | ❌ (lenient for sprint integration) |
+
+---
+
+## Commit Convention (recap)
+
+All commits must follow Conventional Commits:
+
+```
+<type>(<scope>): <short description>
+```
+
+Where `<scope>` for `feat` commits **must** be `US-XX`:
+
+```
+feat(US-05): add resident profile view
+fix(US-03): correct task date format in agenda
+chore(deps): upgrade firebase-admin to 13.x
+```
+
+Sprint-level commits (squash result on `develop`):
+```
+sprint(S3): close sprint S3 — US-05, US-06, US-07
+```
+
+Release commits (squash result on `master`):
+```
+release: v1.3.0 — Sprint S3
+```
+
+---
+
+## Agent Rules
+
+- **DEVELOPER**: Always create task branches from the current `sprint/S{N}`. Never from `develop` directly (unless it's a `docs/` or `chore/` not tied to a sprint).
+- **REVIEWER**: Verify PR target is `sprint/S{N}` for feature work, NOT `develop` directly.
+- **PLANNER**: At sprint start, ensure `sprint/S{N}` exists before assigning tasks.
+- **All agents**: Never push directly to `master` or `develop`. It is blocked by GitHub rulesets.

--- a/scripts/create-sprint.sh
+++ b/scripts/create-sprint.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# scripts/create-sprint.sh
+# Usage: ./scripts/create-sprint.sh <sprint-number>
+# Example: ./scripts/create-sprint.sh 4
+#
+# Creates sprint/S{N} from develop, pushes it to origin,
+# and prints the next steps.
+
+set -e
+
+# ── Validation ──────────────────────────────────────────────────────────────
+if [ -z "$1" ]; then
+  echo "❌  Usage: $0 <sprint-number>"
+  echo "   Example: $0 4"
+  exit 1
+fi
+
+N="$1"
+BRANCH="sprint/S${N}"
+CURRENT_BRANCH=$(git branch --show-current)
+
+# ── Ensure we're on develop and it's up to date ──────────────────────────────
+echo "🔄  Switching to develop and pulling latest..."
+git checkout develop
+git pull origin develop
+
+# ── Check branch doesn't already exist ───────────────────────────────────────
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  echo "⚠️   Branch '${BRANCH}' already exists locally."
+  echo "   If you want to reset it: git branch -D ${BRANCH} && $0 ${N}"
+  exit 1
+fi
+
+if git ls-remote --exit-code --heads origin "${BRANCH}" > /dev/null 2>&1; then
+  echo "⚠️   Branch '${BRANCH}' already exists on origin."
+  echo "   Checking it out locally instead..."
+  git checkout --track "origin/${BRANCH}"
+  echo ""
+  echo "✅  Checked out existing remote branch '${BRANCH}'."
+  exit 0
+fi
+
+# ── Create and push ──────────────────────────────────────────────────────────
+echo "🌿  Creating branch '${BRANCH}' from develop..."
+git checkout -b "${BRANCH}"
+
+echo "🚀  Pushing '${BRANCH}' to origin..."
+git push -u origin "${BRANCH}"
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "✅  Sprint branch ready: ${BRANCH}"
+echo ""
+echo "📋  Next steps:"
+echo "   1. Update PLAN/current-sprint.md with Sprint S${N} details"
+echo "   2. Create task branches from '${BRANCH}':"
+echo "      git checkout ${BRANCH}"
+echo "      git checkout -b feat/US-XX-short-description"
+echo "   3. Open PRs targeting '${BRANCH}', not develop"
+echo "   4. When the sprint closes, open PR: ${BRANCH} → develop"
+echo ""
+echo "🔗  GitHub: https://github.com/DevXoje/gerocultores-system/tree/${BRANCH}"


### PR DESCRIPTION
## Summary

- Adds `AGENTS/git-flow.md` con el modelo de ramas, estrategia de merge, ciclo de vida de sprint y documentación de los rulesets de GitHub
- Adds `scripts/create-sprint.sh` helper para crear `sprint/S{N}` desde develop con validaciones
- Updates `AGENTS.md` para referenciar `git-flow.md`

## GitHub Rulesets actualizados (via API)

| Ruleset | ID | Cambios |
|---|---|---|
| Protección Producción (`master`) | 14951374 | Squash-only, 1 approval requerido, 4 CI checks obligatorios (strict) |
| Protección Desarrollo (`develop`) | 14951445 | Squash-only, CI checks obligatorios |

## Evidencia

El push directo a `master` fue rechazado correctamente por GitHub con:
`remote: - Changes must be made through a pull request.`