### PR TITLE
ci: add automated semantic versioning and GitHub Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,157 @@
+name: Auto Tag & Release
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write # required to push tags and create GitHub Releases
+
+jobs:
+  release:
+    name: Calculate version, tag, and create release
+    runs-on: ubuntu-latest
+    # Skip if the push was itself a release commit (safety guard)
+    if: "!startsWith(github.event.head_commit.message, 'chore(release)')"
+
+    steps:
+      - name: Checkout (full history for git log)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # CRITICAL: shallow clone won't see previous tags
+
+      - name: Calculate next version
+        id: version
+        shell: bash
+        run: |
+          # ── 1. Find base tag ───────────────────────────────────────────────
+          LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -n1)
+          if [ -z "$LAST_TAG" ]; then
+            echo "No previous tag found. Starting from v0.0.0."
+            LAST_TAG="v0.0.0"
+            COMMITS=$(git log --pretty=format:"%s %b" HEAD)
+          else
+            echo "Last tag: $LAST_TAG"
+            COMMITS=$(git log --pretty=format:"%s %b" "${LAST_TAG}..HEAD")
+          fi
+
+          # ── 2. Parse current version ───────────────────────────────────────
+          VERSION="${LAST_TAG#v}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+          # ── 3. Determine bump type ─────────────────────────────────────────
+          HAS_BREAKING=false
+          HAS_FEAT=false
+          HAS_FIX=false
+
+          while IFS= read -r line; do
+            if echo "$line" | grep -qiE "BREAKING[[:space:]]CHANGE|!:"; then
+              HAS_BREAKING=true
+            fi
+            if echo "$line" | grep -qE "^feat(\(.*\))?!?:"; then
+              HAS_FEAT=true
+            fi
+            if echo "$line" | grep -qE "^fix(\(.*\))?!?:"; then
+              HAS_FIX=true
+            fi
+          done <<< "$COMMITS"
+
+          # ── 4. Calculate next version ──────────────────────────────────────
+          if [ "$HAS_BREAKING" = true ]; then
+            NEXT_VERSION="$((MAJOR + 1)).0.0"
+            BUMP_TYPE="MAJOR (breaking change)"
+          elif [ "$HAS_FEAT" = true ]; then
+            NEXT_VERSION="${MAJOR}.$((MINOR + 1)).0"
+            BUMP_TYPE="MINOR (new feature)"
+          elif [ "$HAS_FIX" = true ]; then
+            NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+            BUMP_TYPE="PATCH (bug fix)"
+          else
+            echo "No feat/fix/breaking commits found since $LAST_TAG. Skipping release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          NEXT_TAG="v${NEXT_VERSION}"
+
+          # ── 5. Idempotency check ───────────────────────────────────────────
+          if git tag --list | grep -qx "$NEXT_TAG"; then
+            echo "Tag $NEXT_TAG already exists. Skipping (idempotent)."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Bump type : $BUMP_TYPE"
+          echo "Next tag  : $NEXT_TAG"
+          echo "skip=false"         >> "$GITHUB_OUTPUT"
+          echo "next_tag=$NEXT_TAG" >> "$GITHUB_OUTPUT"
+          echo "last_tag=$LAST_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Build release notes
+        if: steps.version.outputs.skip == 'false'
+        id: notes
+        shell: bash
+        run: |
+          LAST_TAG="${{ steps.version.outputs.last_tag }}"
+
+          if [ "$LAST_TAG" = "v0.0.0" ]; then
+            LOG=$(git log --pretty=format:"%H %s" HEAD)
+          else
+            LOG=$(git log --pretty=format:"%H %s" "${LAST_TAG}..HEAD")
+          fi
+
+          section() {
+            local label="$1"
+            local pattern="$2"
+            local lines
+            lines=$(echo "$LOG" | grep -E "$pattern" || true)
+            if [ -n "$lines" ]; then
+              echo "### $label"
+              while IFS= read -r entry; do
+                SHA=$(echo "$entry" | cut -c1-7)
+                MSG=$(echo "$entry" | cut -c9-)
+                echo "- ${MSG} (\`${SHA}\`)"
+              done <<< "$lines"
+              echo ""
+            fi
+          }
+
+          {
+            section "🚀 New Features"   "^[a-f0-9]+ feat"
+            section "🐛 Bug Fixes"      "^[a-f0-9]+ fix"
+            section "♻️  Refactors"     "^[a-f0-9]+ refactor"
+            section "🧪 Tests"          "^[a-f0-9]+ test"
+            section "📦 Chores"         "^[a-f0-9]+ chore"
+            section "📚 Documentation"  "^[a-f0-9]+ docs"
+            section "⚡ Performance"    "^[a-f0-9]+ perf"
+          } > /tmp/release-notes.md
+
+          # Fallback if no categorized commits
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "No categorized commits in this release." > /tmp/release-notes.md
+          fi
+
+          echo "Release notes:"
+          cat /tmp/release-notes.md
+
+      - name: Create annotated tag
+        if: steps.version.outputs.skip == 'false'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.next_tag }}" \
+                  -m "Release ${{ steps.version.outputs.next_tag }}"
+          git push origin "${{ steps.version.outputs.next_tag }}"
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.skip == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.next_tag }}
+          name: Release ${{ steps.version.outputs.next_tag }}
+          body_path: /tmp/release-notes.md
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Linked Issue

Closes #43

## PR Type

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance / tooling

## Summary

- Añade `.github/workflows/release.yml` que se dispara en cada push a \`master\`
- Calcula la siguiente versión semántica automáticamente desde los commits Conventional Commits desde el último tag
- Crea un tag anotado y un GitHub Release con notas agrupadas por tipo de commit

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Nuevo workflow de auto-release |

## Versioning logic

| Commit type | Bump |
|-------------|------|
| \`feat\` | MINOR → \`v0.X.0\` |
| \`fix\` | PATCH → \`v0.0.X\` |
| \`BREAKING CHANGE\` | MAJOR → \`vX.0.0\` |
| \`chore\` / \`docs\` / \`ci\` | Sin release (skip) |

## Test Plan

- [x] Revisión manual del script bash — lógica de bump verificada
- [x] Tag \`v0.2.0\` retroactivo creado manualmente y subido a GitHub como baseline
- [ ] Verificar que el Action corre correctamente al mergear esta PR a \`master\` (el commit es \`ci:\` → debe hacer skip sin crear tag)