### PR TITLE
feat(US-05): implement GET /api/residentes/:id endpoint

### DIFF
--- a/SPEC/api/contracts/residentes.md
+++ b/SPEC/api/contracts/residentes.md
@@ -1,0 +1,57 @@
+# API Contract: Residentes
+
+> Delta spec — Sprint 3 (US-05)
+> Canonical entity fields: SPEC/entities.md → Residente
+
+---
+
+## GET /api/residentes/:id
+
+**US**: US-05 — Consulta de ficha de residente
+
+### Auth
+
+Requires valid Firebase ID token (`Authorization: Bearer <token>`).
+Accessible to roles: `admin`, `gerocultor`.
+
+### Path Parameters
+
+| Parameter | Type   | Required | Description             |
+|-----------|--------|----------|-------------------------|
+| `id`      | string | yes      | Firestore document ID of the Residente |
+
+### Success Response — 200 OK
+
+```json
+{
+  "data": {
+    "id": "string",
+    "nombre": "string",
+    "apellidos": "string",
+    "fechaNacimiento": "string (ISO 8601)",
+    "habitacion": "string",
+    "foto": "string | null",
+    "diagnosticos": "string | null",
+    "alergias": "string | null",
+    "medicacion": "string | null",
+    "preferencias": "string | null",
+    "archivado": "boolean",
+    "creadoEn": "string (ISO 8601)",
+    "actualizadoEn": "string (ISO 8601)"
+  }
+}
+```
+
+### Error Responses
+
+| Status | Code        | When                              |
+|--------|-------------|-----------------------------------|
+| 401    | UNAUTHORIZED | Missing or invalid Bearer token   |
+| 404    | NOT_FOUND    | No Residente with the given id    |
+| 500    | (none)       | Unexpected server error           |
+
+### Notes
+
+- The fields `diagnosticos`, `alergias`, `medicacion`, `preferencias`, and `fechaNacimiento` are RGPD category-special data (art. 9). Only accessible to authenticated users with role `admin` or `gerocultor`.
+- `foto` is a URL to the resident photo. Photo uploads are NOT implemented in this sprint (design-only until SPEC update).
+- Future enhancement: filter resident visibility for `gerocultor` to only show assigned residents via `ResidenteAsignacion`.

--- a/SPEC/api/contracts/residentes.md
+++ b/SPEC/api/contracts/residentes.md
@@ -47,6 +47,7 @@ Accessible to roles: `admin`, `gerocultor`.
 | Status | Code        | When                              |
 |--------|-------------|-----------------------------------|
 | 401    | UNAUTHORIZED | Missing or invalid Bearer token   |
+| 403    | FORBIDDEN    | Gerocultor is not in `gerocultoresAsignados` for this resident |
 | 404    | NOT_FOUND    | No Residente with the given id    |
 | 500    | (none)       | Unexpected server error           |
 
@@ -54,4 +55,5 @@ Accessible to roles: `admin`, `gerocultor`.
 
 - The fields `diagnosticos`, `alergias`, `medicacion`, `preferencias`, and `fechaNacimiento` are RGPD category-special data (art. 9). Only accessible to authenticated users with role `admin` or `gerocultor`.
 - `foto` is a URL to the resident photo. Photo uploads are NOT implemented in this sprint (design-only until SPEC update).
-- Future enhancement: filter resident visibility for `gerocultor` to only show assigned residents via `ResidenteAsignacion`.
+- **Access control**: `admin` can access any resident. `gerocultor` can only access residents where their `uid` is present in the `gerocultoresAsignados` array stored in the Firestore document.
+- `gerocultoresAsignados` is an internal field and is **never** returned in the API response.

--- a/code/api/src/controllers/residentes.controller.spec.ts
+++ b/code/api/src/controllers/residentes.controller.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * residentes.controller.spec.ts — Supertest controller-level tests for /api/residentes.
+ *
+ * ResidentesService is fully mocked — no Firestore or Firebase Auth calls happen.
+ * verifyAuth is mocked to inject req.user.
+ *
+ * US-05: Consulta de ficha de residente
+ */
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+
+// Mock firebase module BEFORE any imports that depend on it.
+vi.mock('../services/firebase', () => ({
+  adminAuth: {
+    verifyIdToken: vi.fn(),
+  },
+  adminDb: {
+    collection: vi.fn().mockReturnValue({
+      get: vi.fn(),
+      doc: vi.fn().mockReturnValue({
+        get: vi.fn(),
+      }),
+    }),
+  },
+}))
+
+// Mock ResidentesService — test HTTP layer only.
+vi.mock('../services/residentes.service')
+
+// Bypass verifyAuth: inject a fake req.user for all requests.
+vi.mock('../middleware/verifyAuth', () => ({
+  verifyAuth: (
+    req: { headers: { authorization?: string; 'x-test-role'?: string; 'x-test-uid'?: string }; user?: unknown },
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+    next: () => void,
+  ) => {
+    if (!req.headers.authorization) {
+      res.status(401).json({ error: 'Token no provisto o inválido', code: 'UNAUTHORIZED' })
+      return
+    }
+    const role = req.headers['x-test-role'] ?? 'admin'
+    const uid = req.headers['x-test-uid'] ?? 'test-admin-uid'
+    req.user = { uid, role }
+    next()
+  },
+}))
+
+import { ResidentesService, NotFoundError } from '../services/residentes.service'
+import app from '../app'
+
+// ─── Mocked service methods ────────────────────────────────────────────────────
+
+const mockGetResidenteById = vi.mocked(ResidentesService.prototype.getResidenteById)
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const sampleResidente = {
+  id: 'res-001',
+  nombre: 'María',
+  apellidos: 'García López',
+  fechaNacimiento: '1940-05-15',
+  habitacion: '101A',
+  foto: null,
+  diagnosticos: 'Alzheimer leve',
+  alergias: 'Penicilina',
+  medicacion: 'Donepezilo 5mg',
+  preferencias: 'Prefiere ducharse por la mañana',
+  archivado: false,
+  creadoEn: '2026-01-01T00:00:00.000Z',
+  actualizadoEn: '2026-04-01T00:00:00.000Z',
+}
+
+const AUTH_HEADER = 'Bearer valid-token'
+
+// ─── GET /api/residentes/:id ──────────────────────────────────────────────────
+
+describe('GET /api/residentes/:id — getResidente', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 200 with the residente when found', async () => {
+    mockGetResidenteById.mockResolvedValueOnce(sampleResidente)
+
+    const res = await request(app)
+      .get('/api/residentes/res-001')
+      .set('Authorization', AUTH_HEADER)
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ data: sampleResidente })
+    expect(mockGetResidenteById).toHaveBeenCalledWith('res-001')
+  })
+
+  it('returns 404 when residente does not exist', async () => {
+    mockGetResidenteById.mockRejectedValueOnce(new NotFoundError('Residente not found'))
+
+    const res = await request(app)
+      .get('/api/residentes/non-existent')
+      .set('Authorization', AUTH_HEADER)
+
+    expect(res.status).toBe(404)
+    expect(res.body).toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it('returns 401 when no Authorization header is provided', async () => {
+    const res = await request(app).get('/api/residentes/res-001')
+
+    expect(res.status).toBe(401)
+    expect(res.body).toMatchObject({ code: 'UNAUTHORIZED' })
+    expect(mockGetResidenteById).not.toHaveBeenCalled()
+  })
+
+  it('returns 200 when gerocultor requests a residente', async () => {
+    mockGetResidenteById.mockResolvedValueOnce(sampleResidente)
+
+    const res = await request(app)
+      .get('/api/residentes/res-001')
+      .set('Authorization', AUTH_HEADER)
+      .set('x-test-role', 'gerocultor')
+      .set('x-test-uid', 'uid-gerocultor-1')
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ data: sampleResidente })
+  })
+
+  it('passes error to errorHandler (returns 500) when service throws unexpectedly', async () => {
+    mockGetResidenteById.mockRejectedValueOnce(new Error('Unexpected DB error'))
+
+    const res = await request(app)
+      .get('/api/residentes/res-001')
+      .set('Authorization', AUTH_HEADER)
+
+    expect(res.status).toBe(500)
+  })
+})

--- a/code/api/src/controllers/residentes.controller.spec.ts
+++ b/code/api/src/controllers/residentes.controller.spec.ts
@@ -2,7 +2,7 @@
  * residentes.controller.spec.ts — Supertest controller-level tests for /api/residentes.
  *
  * ResidentesService is fully mocked — no Firestore or Firebase Auth calls happen.
- * verifyAuth is mocked to inject req.user.
+ * verifyAuth is mocked to inject req.user; authorization logic tested via service mock.
  *
  * US-05: Consulta de ficha de residente
  */
@@ -20,17 +20,19 @@ vi.mock('../services/firebase', () => ({
       doc: vi.fn().mockReturnValue({
         get: vi.fn(),
       }),
+      where: vi.fn().mockReturnThis(),
     }),
+    runTransaction: vi.fn(),
   },
 }))
 
-// Mock ResidentesService — test HTTP layer only.
+// Mock ResidentesService — we test the HTTP layer only.
 vi.mock('../services/residentes.service')
 
-// Bypass verifyAuth: inject a fake req.user for all requests.
+// Bypass verifyAuth: inject a fake req.user for all requests in this suite.
 vi.mock('../middleware/verifyAuth', () => ({
   verifyAuth: (
-    req: { headers: { authorization?: string; 'x-test-role'?: string; 'x-test-uid'?: string }; user?: unknown },
+    req: { headers: { authorization?: string }; user?: unknown },
     res: { status: (code: number) => { json: (body: unknown) => void } },
     next: () => void,
   ) => {
@@ -38,14 +40,15 @@ vi.mock('../middleware/verifyAuth', () => ({
       res.status(401).json({ error: 'Token no provisto o inválido', code: 'UNAUTHORIZED' })
       return
     }
-    const role = req.headers['x-test-role'] ?? 'admin'
-    const uid = req.headers['x-test-uid'] ?? 'test-admin-uid'
-    req.user = { uid, role }
+    const roleHeader = (req as { headers: { 'x-test-role'?: string } }).headers['x-test-role']
+    const uid = (req as { headers: { 'x-test-uid'?: string } }).headers['x-test-uid'] ?? 'test-admin-uid'
+    const role = roleHeader ?? 'admin'
+    req.user = { uid, rol: role, role }
     next()
   },
 }))
 
-import { ResidentesService, NotFoundError } from '../services/residentes.service'
+import { ResidentesService, NotFoundError, ForbiddenError } from '../services/residentes.service'
 import app from '../app'
 
 // ─── Mocked service methods ────────────────────────────────────────────────────
@@ -55,22 +58,23 @@ const mockGetResidenteById = vi.mocked(ResidentesService.prototype.getResidenteB
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
 const sampleResidente = {
-  id: 'res-001',
-  nombre: 'María',
-  apellidos: 'García López',
-  fechaNacimiento: '1940-05-15',
-  habitacion: '101A',
+  id: 'res-uuid-001',
+  nombre: 'Eleanor',
+  apellidos: 'Vance',
+  fechaNacimiento: '1940-05-12',
+  habitacion: '204',
   foto: null,
-  diagnosticos: 'Alzheimer leve',
+  diagnosticos: 'Demencia leve',
   alergias: 'Penicilina',
-  medicacion: 'Donepezilo 5mg',
-  preferencias: 'Prefiere ducharse por la mañana',
+  medicacion: 'Donepezilo 10mg',
+  preferencias: 'Prefiere desayuno temprano',
   archivado: false,
-  creadoEn: '2026-01-01T00:00:00.000Z',
-  actualizadoEn: '2026-04-01T00:00:00.000Z',
+  creadoEn: '2026-01-01T10:00:00Z',
+  actualizadoEn: '2026-04-01T10:00:00Z',
 }
 
 const AUTH_HEADER = 'Bearer valid-token'
+const GERO_UID = 'gero-uid-001'
 
 // ─── GET /api/residentes/:id ──────────────────────────────────────────────────
 
@@ -79,23 +83,51 @@ describe('GET /api/residentes/:id — getResidente', () => {
     vi.clearAllMocks()
   })
 
-  it('returns 200 with the residente when found', async () => {
+  it('returns 200 with residente data when admin requests', async () => {
     mockGetResidenteById.mockResolvedValueOnce(sampleResidente)
 
     const res = await request(app)
-      .get('/api/residentes/res-001')
+      .get('/api/residentes/res-uuid-001')
       .set('Authorization', AUTH_HEADER)
 
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ data: sampleResidente })
-    expect(mockGetResidenteById).toHaveBeenCalledWith('res-001')
+    expect(mockGetResidenteById).toHaveBeenCalledWith('res-uuid-001', 'test-admin-uid', 'admin')
+  })
+
+  it('returns 200 when gerocultor requests an assigned resident', async () => {
+    mockGetResidenteById.mockResolvedValueOnce(sampleResidente)
+
+    const res = await request(app)
+      .get('/api/residentes/res-uuid-001')
+      .set('Authorization', AUTH_HEADER)
+      .set('x-test-role', 'gerocultor')
+      .set('x-test-uid', GERO_UID)
+
+    expect(res.status).toBe(200)
+    expect(mockGetResidenteById).toHaveBeenCalledWith('res-uuid-001', GERO_UID, 'gerocultor')
+  })
+
+  it('returns 403 when gerocultor requests a non-assigned resident', async () => {
+    mockGetResidenteById.mockRejectedValueOnce(
+      new ForbiddenError('No tienes acceso a este residente'),
+    )
+
+    const res = await request(app)
+      .get('/api/residentes/res-uuid-001')
+      .set('Authorization', AUTH_HEADER)
+      .set('x-test-role', 'gerocultor')
+      .set('x-test-uid', 'other-gero-uid')
+
+    expect(res.status).toBe(403)
+    expect(res.body).toMatchObject({ code: 'FORBIDDEN' })
   })
 
   it('returns 404 when residente does not exist', async () => {
     mockGetResidenteById.mockRejectedValueOnce(new NotFoundError('Residente not found'))
 
     const res = await request(app)
-      .get('/api/residentes/non-existent')
+      .get('/api/residentes/non-existent-id')
       .set('Authorization', AUTH_HEADER)
 
     expect(res.status).toBe(404)
@@ -103,31 +135,18 @@ describe('GET /api/residentes/:id — getResidente', () => {
   })
 
   it('returns 401 when no Authorization header is provided', async () => {
-    const res = await request(app).get('/api/residentes/res-001')
+    const res = await request(app).get('/api/residentes/res-uuid-001')
 
     expect(res.status).toBe(401)
     expect(res.body).toMatchObject({ code: 'UNAUTHORIZED' })
     expect(mockGetResidenteById).not.toHaveBeenCalled()
   })
 
-  it('returns 200 when gerocultor requests a residente', async () => {
-    mockGetResidenteById.mockResolvedValueOnce(sampleResidente)
-
-    const res = await request(app)
-      .get('/api/residentes/res-001')
-      .set('Authorization', AUTH_HEADER)
-      .set('x-test-role', 'gerocultor')
-      .set('x-test-uid', 'uid-gerocultor-1')
-
-    expect(res.status).toBe(200)
-    expect(res.body).toEqual({ data: sampleResidente })
-  })
-
   it('passes error to errorHandler (returns 500) when service throws unexpectedly', async () => {
     mockGetResidenteById.mockRejectedValueOnce(new Error('Unexpected DB error'))
 
     const res = await request(app)
-      .get('/api/residentes/res-001')
+      .get('/api/residentes/res-uuid-001')
       .set('Authorization', AUTH_HEADER)
 
     expect(res.status).toBe(500)

--- a/code/api/src/controllers/residentes.controller.ts
+++ b/code/api/src/controllers/residentes.controller.ts
@@ -1,0 +1,32 @@
+/**
+ * residentes.controller.ts — HTTP layer for /api/residentes
+ *
+ * US-05: Consulta de ficha de residente
+ */
+import type { Request, Response, NextFunction } from 'express'
+import { ResidentesService, NotFoundError } from '../services/residentes.service'
+
+export class ResidentesController {
+  private service = new ResidentesService()
+
+  /**
+   * GET /api/residentes/:id
+   * Returns the Residente document for the given id.
+   * Accessible by both admin and gerocultor.
+   * US-05 authorization rule: both roles may read resident details
+   * (gerocultor visibility scoped to assigned residents is a future enhancement).
+   */
+  getResidente = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const id = req.params['id'] as string
+      const residente = await this.service.getResidenteById(id)
+      res.json({ data: residente })
+    } catch (e) {
+      if (e instanceof NotFoundError) {
+        res.status(404).json({ error: e.message, code: 'NOT_FOUND' })
+        return
+      }
+      next(e)
+    }
+  }
+}

--- a/code/api/src/controllers/residentes.controller.ts
+++ b/code/api/src/controllers/residentes.controller.ts
@@ -1,29 +1,41 @@
 /**
- * residentes.controller.ts — HTTP layer for /api/residentes
+ * residentes.controller.ts — HTTP layer for Residente endpoints.
  *
  * US-05: Consulta de ficha de residente
  */
 import type { Request, Response, NextFunction } from 'express'
-import { ResidentesService, NotFoundError } from '../services/residentes.service'
+import { ResidentesService, NotFoundError, ForbiddenError } from '../services/residentes.service'
+import { ResidenteIdParamSchema } from '../types/residente.types'
+import type { UserRole } from '../types/user.types'
 
 export class ResidentesController {
   private service = new ResidentesService()
 
-  /**
-   * GET /api/residentes/:id
-   * Returns the Residente document for the given id.
-   * Accessible by both admin and gerocultor.
-   * US-05 authorization rule: both roles may read resident details
-   * (gerocultor visibility scoped to assigned residents is a future enhancement).
-   */
   getResidente = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      const id = req.params['id'] as string
-      const residente = await this.service.getResidenteById(id)
+      const parsed = ResidenteIdParamSchema.safeParse(req.params)
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Parámetros inválidos',
+          code: 'VALIDATION_ERROR',
+          details: parsed.error.flatten().fieldErrors,
+        })
+        return
+      }
+
+      const { id } = parsed.data
+      const userRole = req.user?.['role'] as UserRole
+      const userUid = req.user?.uid as string
+
+      const residente = await this.service.getResidenteById(id, userUid, userRole)
       res.json({ data: residente })
     } catch (e) {
       if (e instanceof NotFoundError) {
         res.status(404).json({ error: e.message, code: 'NOT_FOUND' })
+        return
+      }
+      if (e instanceof ForbiddenError) {
+        res.status(403).json({ error: e.message, code: 'FORBIDDEN' })
         return
       }
       next(e)

--- a/code/api/src/routes/index.ts
+++ b/code/api/src/routes/index.ts
@@ -1,6 +1,5 @@
 import { Router } from 'express'
 import { verifyAuth } from '../middleware/verifyAuth'
-import { requireRole } from '../middleware/requireRole'
 import adminUsersRouter from './admin.users.routes'
 import tareasRouter from './tareas.routes'
 import residentesRouter from './residentes.routes'

--- a/code/api/src/routes/index.ts
+++ b/code/api/src/routes/index.ts
@@ -1,7 +1,9 @@
 import { Router } from 'express'
 import { verifyAuth } from '../middleware/verifyAuth'
+import { requireRole } from '../middleware/requireRole'
 import adminUsersRouter from './admin.users.routes'
 import tareasRouter from './tareas.routes'
+import residentesRouter from './residentes.routes'
 
 const router = Router()
 
@@ -24,5 +26,6 @@ protectedRouter.get('/', (_req, res) => {
 router.use('/api/protected', protectedRouter)
 router.use('/api/admin/users', adminUsersRouter)
 router.use('/api/tareas', tareasRouter)
+router.use('/api/residentes', residentesRouter)
 
 export default router

--- a/code/api/src/routes/residentes.routes.ts
+++ b/code/api/src/routes/residentes.routes.ts
@@ -8,7 +8,7 @@ const controller = new ResidentesController()
 // All residentes routes require authentication
 router.use(verifyAuth)
 
-// Both roles can access resident details; business rules enforced in controller/service
+// GET /api/residentes/:id — US-05
 router.get('/:id', controller.getResidente)
 
 export default router

--- a/code/api/src/routes/residentes.routes.ts
+++ b/code/api/src/routes/residentes.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express'
+import { verifyAuth } from '../middleware/verifyAuth'
+import { ResidentesController } from '../controllers/residentes.controller'
+
+const router = Router()
+const controller = new ResidentesController()
+
+// All residentes routes require authentication
+router.use(verifyAuth)
+
+// Both roles can access resident details; business rules enforced in controller/service
+router.get('/:id', controller.getResidente)
+
+export default router

--- a/code/api/src/services/residentes.service.integration.spec.ts
+++ b/code/api/src/services/residentes.service.integration.spec.ts
@@ -12,7 +12,7 @@
  *   FIREBASE_PROJECT_ID=gerocultores-test
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
 import * as admin from 'firebase-admin'
 import type { ResidenteDoc } from '../types/residente.types'
 import { COLLECTIONS } from './collections'
@@ -20,7 +20,6 @@ import { COLLECTIONS } from './collections'
 // ─── Emulator setup ──────────────────────────────────────────────────────────
 
 const PROJECT_ID = process.env['FIREBASE_PROJECT_ID'] ?? 'gerocultores-test'
-
 const TEST_APP_NAME = 'integration-residentes-test'
 
 let testApp: admin.app.App
@@ -43,29 +42,29 @@ afterAll(async () => {
 })
 
 // ─── Import service ───────────────────────────────────────────────────────────
+import { ResidentesService, NotFoundError, ForbiddenError } from './residentes.service'
 
-import { ResidentesService, NotFoundError } from './residentes.service'
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function now(): string {
-  return new Date().toISOString()
-}
+const GERO_UID = 'gero-uid-integration-test'
+const ADMIN_UID = 'admin-uid-integration-test'
+const OTHER_GERO_UID = 'other-gero-uid-integration-test'
 
 function buildResidenteDoc(overrides: Partial<ResidenteDoc> = {}): ResidenteDoc {
   return {
-    nombre: 'María',
-    apellidos: 'García López',
-    fechaNacimiento: '1940-05-15',
-    habitacion: '101A',
+    nombre: 'Eleanor',
+    apellidos: 'Vance',
+    fechaNacimiento: '1940-05-12',
+    habitacion: '204',
     foto: null,
-    diagnosticos: 'Alzheimer leve',
+    diagnosticos: 'Demencia leve',
     alergias: 'Penicilina',
-    medicacion: 'Donepezilo 5mg',
-    preferencias: 'Prefiere ducharse por la mañana',
+    medicacion: 'Donepezilo 10mg',
+    preferencias: 'Prefiere desayuno temprano',
     archivado: false,
-    creadoEn: now(),
-    actualizadoEn: now(),
+    gerocultoresAsignados: [GERO_UID],
+    creadoEn: new Date().toISOString(),
+    actualizadoEn: new Date().toISOString(),
     ...overrides,
   }
 }
@@ -84,36 +83,102 @@ async function deleteResidente(id: string): Promise<void> {
 describe('ResidentesService integration (Firestore Emulator)', () => {
   let service: ResidentesService
 
-  beforeAll(() => {
+  beforeEach(() => {
     service = new ResidentesService()
   })
 
-  describe('getResidenteById', () => {
-    it('returns the residente when it exists', async () => {
+  // ──────────────────────────────────────────────────────────────────────────
+  // getResidenteById — Happy paths
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('getResidenteById — happy paths', () => {
+    it('admin can access any resident', async () => {
       const doc = buildResidenteDoc()
       const id = await seedResidente(doc)
 
       try {
-        const result = await service.getResidenteById(id)
+        const result = await service.getResidenteById(id, ADMIN_UID, 'admin')
 
         expect(result.id).toBe(id)
-        expect(result.nombre).toBe(doc.nombre)
-        expect(result.apellidos).toBe(doc.apellidos)
-        expect(result.habitacion).toBe(doc.habitacion)
+        expect(result.nombre).toBe('Eleanor')
+        expect(result.apellidos).toBe('Vance')
+        expect(result.diagnosticos).toBe('Demencia leve')
+        expect(result.alergias).toBe('Penicilina')
+        expect(result.medicacion).toBe('Donepezilo 10mg')
+        expect(result.preferencias).toBe('Prefiere desayuno temprano')
         expect(result.archivado).toBe(false)
-        expect(result.foto).toBeNull()
-        expect(result.diagnosticos).toBe(doc.diagnosticos)
-        expect(result.alergias).toBe(doc.alergias)
+        // gerocultoresAsignados must NOT be in the response
+        expect((result as Record<string, unknown>)['gerocultoresAsignados']).toBeUndefined()
       } finally {
         await deleteResidente(id)
       }
     })
 
-    it('throws NotFoundError when the id does not exist', async () => {
-      await expect(service.getResidenteById('non-existent-id-xyz')).rejects.toThrow(NotFoundError)
+    it('gerocultor assigned to resident can access their data', async () => {
+      const doc = buildResidenteDoc({ gerocultoresAsignados: [GERO_UID] })
+      const id = await seedResidente(doc)
+
+      try {
+        const result = await service.getResidenteById(id, GERO_UID, 'gerocultor')
+
+        expect(result.id).toBe(id)
+        expect(result.nombre).toBe('Eleanor')
+      } finally {
+        await deleteResidente(id)
+      }
+    })
+  })
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // getResidenteById — Access control (403)
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('getResidenteById — access control', () => {
+    it('throws ForbiddenError when gerocultor is not assigned to the resident', async () => {
+      const doc = buildResidenteDoc({ gerocultoresAsignados: [GERO_UID] })
+      const id = await seedResidente(doc)
+
+      try {
+        await expect(
+          service.getResidenteById(id, OTHER_GERO_UID, 'gerocultor'),
+        ).rejects.toThrow(ForbiddenError)
+      } finally {
+        await deleteResidente(id)
+      }
     })
 
-    it('correctly maps a residente with all nullable fields set to null', async () => {
+    it('throws ForbiddenError when gerocultoresAsignados is empty', async () => {
+      const doc = buildResidenteDoc({ gerocultoresAsignados: [] })
+      const id = await seedResidente(doc)
+
+      try {
+        await expect(
+          service.getResidenteById(id, GERO_UID, 'gerocultor'),
+        ).rejects.toThrow(ForbiddenError)
+      } finally {
+        await deleteResidente(id)
+      }
+    })
+  })
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // getResidenteById — Not found (404)
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('getResidenteById — not found', () => {
+    it('throws NotFoundError when resident id does not exist', async () => {
+      await expect(
+        service.getResidenteById('nonexistent-resident-id-xyz', ADMIN_UID, 'admin'),
+      ).rejects.toThrow(NotFoundError)
+    })
+  })
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // getResidenteById — Null/optional fields
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('getResidenteById — optional fields', () => {
+    it('returns null for optional fields when absent from Firestore', async () => {
       const doc = buildResidenteDoc({
         foto: null,
         diagnosticos: null,
@@ -124,7 +189,7 @@ describe('ResidentesService integration (Firestore Emulator)', () => {
       const id = await seedResidente(doc)
 
       try {
-        const result = await service.getResidenteById(id)
+        const result = await service.getResidenteById(id, ADMIN_UID, 'admin')
 
         expect(result.foto).toBeNull()
         expect(result.diagnosticos).toBeNull()

--- a/code/api/src/services/residentes.service.integration.spec.ts
+++ b/code/api/src/services/residentes.service.integration.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * residentes.service.integration.spec.ts — Integration tests for ResidentesService.
+ *
+ * These tests run against the real Firebase Firestore Emulator.
+ * Before running, ensure the emulator is started on port 8080:
+ *   firebase emulators:exec --only firestore "cd code/api && npm test -- --config=vitest.integration.config.ts"
+ *
+ * US-05: Consulta de ficha de residente
+ *
+ * Required env vars:
+ *   FIRESTORE_EMULATOR_HOST=localhost:8080
+ *   FIREBASE_PROJECT_ID=gerocultores-test
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import * as admin from 'firebase-admin'
+import type { ResidenteDoc } from '../types/residente.types'
+import { COLLECTIONS } from './collections'
+
+// ─── Emulator setup ──────────────────────────────────────────────────────────
+
+const PROJECT_ID = process.env['FIREBASE_PROJECT_ID'] ?? 'gerocultores-test'
+
+const TEST_APP_NAME = 'integration-residentes-test'
+
+let testApp: admin.app.App
+let testDb: admin.firestore.Firestore
+
+beforeAll(() => {
+  const existing = admin.apps.find((a) => a?.name === TEST_APP_NAME)
+  if (existing) {
+    testApp = existing
+  } else {
+    testApp = admin.initializeApp({ projectId: PROJECT_ID }, TEST_APP_NAME)
+  }
+  testDb = testApp.firestore()
+})
+
+afterAll(async () => {
+  if (testApp) {
+    await testApp.delete()
+  }
+})
+
+// ─── Import service ───────────────────────────────────────────────────────────
+
+import { ResidentesService, NotFoundError } from './residentes.service'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function now(): string {
+  return new Date().toISOString()
+}
+
+function buildResidenteDoc(overrides: Partial<ResidenteDoc> = {}): ResidenteDoc {
+  return {
+    nombre: 'María',
+    apellidos: 'García López',
+    fechaNacimiento: '1940-05-15',
+    habitacion: '101A',
+    foto: null,
+    diagnosticos: 'Alzheimer leve',
+    alergias: 'Penicilina',
+    medicacion: 'Donepezilo 5mg',
+    preferencias: 'Prefiere ducharse por la mañana',
+    archivado: false,
+    creadoEn: now(),
+    actualizadoEn: now(),
+    ...overrides,
+  }
+}
+
+async function seedResidente(data: ResidenteDoc): Promise<string> {
+  const ref = await testDb.collection(COLLECTIONS.residentes).add(data)
+  return ref.id
+}
+
+async function deleteResidente(id: string): Promise<void> {
+  await testDb.collection(COLLECTIONS.residentes).doc(id).delete()
+}
+
+// ─── Test Suite ──────────────────────────────────────────────────────────────
+
+describe('ResidentesService integration (Firestore Emulator)', () => {
+  let service: ResidentesService
+
+  beforeAll(() => {
+    service = new ResidentesService()
+  })
+
+  describe('getResidenteById', () => {
+    it('returns the residente when it exists', async () => {
+      const doc = buildResidenteDoc()
+      const id = await seedResidente(doc)
+
+      try {
+        const result = await service.getResidenteById(id)
+
+        expect(result.id).toBe(id)
+        expect(result.nombre).toBe(doc.nombre)
+        expect(result.apellidos).toBe(doc.apellidos)
+        expect(result.habitacion).toBe(doc.habitacion)
+        expect(result.archivado).toBe(false)
+        expect(result.foto).toBeNull()
+        expect(result.diagnosticos).toBe(doc.diagnosticos)
+        expect(result.alergias).toBe(doc.alergias)
+      } finally {
+        await deleteResidente(id)
+      }
+    })
+
+    it('throws NotFoundError when the id does not exist', async () => {
+      await expect(service.getResidenteById('non-existent-id-xyz')).rejects.toThrow(NotFoundError)
+    })
+
+    it('correctly maps a residente with all nullable fields set to null', async () => {
+      const doc = buildResidenteDoc({
+        foto: null,
+        diagnosticos: null,
+        alergias: null,
+        medicacion: null,
+        preferencias: null,
+      })
+      const id = await seedResidente(doc)
+
+      try {
+        const result = await service.getResidenteById(id)
+
+        expect(result.foto).toBeNull()
+        expect(result.diagnosticos).toBeNull()
+        expect(result.alergias).toBeNull()
+        expect(result.medicacion).toBeNull()
+        expect(result.preferencias).toBeNull()
+      } finally {
+        await deleteResidente(id)
+      }
+    })
+  })
+})

--- a/code/api/src/services/residentes.service.spec.ts
+++ b/code/api/src/services/residentes.service.spec.ts
@@ -1,117 +1,179 @@
 /**
  * residentes.service.spec.ts — Unit tests for ResidentesService.
  *
- * Firestore is fully mocked — no emulator needed.
+ * Firestore is fully mocked — no real Firebase calls happen.
+ *
  * US-05: Consulta de ficha de residente
  */
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 
-// Mock firebase before any service imports
-vi.mock('./firebase', () => ({
-  adminDb: {
-    collection: vi.fn(),
-  },
-}))
+// ─── Mock Firebase before any imports ────────────────────────────────────────
+vi.mock('../services/firebase', () => {
+  const mockDocRef = {
+    get: vi.fn(),
+  }
 
+  const mockCollectionRef = {
+    doc: vi.fn(() => mockDocRef),
+  }
+
+  return {
+    adminAuth: {},
+    adminDb: {
+      collection: vi.fn(() => mockCollectionRef),
+      _mockDocRef: mockDocRef,
+      _mockCollectionRef: mockCollectionRef,
+    },
+  }
+})
+
+import { ResidentesService, NotFoundError, ForbiddenError } from './residentes.service'
 import { adminDb } from './firebase'
-import { ResidentesService, NotFoundError } from './residentes.service'
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
-const sampleData = {
-  nombre: 'María',
-  apellidos: 'García López',
-  fechaNacimiento: '1940-05-15',
-  habitacion: '101A',
+const geroUid = 'gero-uid-001'
+const adminUid = 'admin-uid-001'
+const residenteId = 'res-uuid-001'
+
+const sampleResidenteData = {
+  nombre: 'Eleanor',
+  apellidos: 'Vance',
+  fechaNacimiento: '1940-05-12',
+  habitacion: '204',
   foto: null,
-  diagnosticos: 'Alzheimer leve',
+  diagnosticos: 'Demencia leve',
   alergias: 'Penicilina',
-  medicacion: 'Donepezilo 5mg',
-  preferencias: 'Prefiere ducharse por la mañana',
+  medicacion: 'Donepezilo 10mg',
+  preferencias: 'Prefiere desayuno temprano',
   archivado: false,
-  creadoEn: '2026-01-01T00:00:00.000Z',
-  actualizadoEn: '2026-04-01T00:00:00.000Z',
+  gerocultoresAsignados: [geroUid],
+  creadoEn: '2026-01-01T10:00:00Z',
+  actualizadoEn: '2026-04-01T10:00:00Z',
 }
 
-describe('ResidentesService', () => {
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getMocks() {
+  const db = adminDb as unknown as {
+    _mockDocRef: { get: ReturnType<typeof vi.fn> }
+    _mockCollectionRef: { doc: ReturnType<typeof vi.fn> }
+  }
+  return {
+    docRef: db._mockDocRef,
+    collectionRef: db._mockCollectionRef,
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ResidentesService.getResidenteById', () => {
   let service: ResidentesService
-  let mockDocGet: ReturnType<typeof vi.fn>
-  let mockDoc: ReturnType<typeof vi.fn>
-  let mockCollection: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     vi.clearAllMocks()
     service = new ResidentesService()
-
-    mockDocGet = vi.fn()
-    mockDoc = vi.fn().mockReturnValue({ get: mockDocGet })
-    mockCollection = vi.fn().mockReturnValue({ doc: mockDoc })
-    vi.mocked(adminDb.collection).mockImplementation(mockCollection)
+    const { collectionRef, docRef } = getMocks()
+    collectionRef.doc.mockReturnValue(docRef)
   })
 
-  describe('getResidenteById', () => {
-    it('returns ResidenteResponse when document exists', async () => {
-      mockDocGet.mockResolvedValueOnce({
-        exists: true,
-        id: 'res-001',
-        data: () => sampleData,
-      })
-
-      const result = await service.getResidenteById('res-001')
-
-      expect(result.id).toBe('res-001')
-      expect(result.nombre).toBe(sampleData.nombre)
-      expect(result.apellidos).toBe(sampleData.apellidos)
-      expect(result.habitacion).toBe(sampleData.habitacion)
-      expect(result.archivado).toBe(false)
-      expect(result.foto).toBeNull()
-      expect(result.diagnosticos).toBe(sampleData.diagnosticos)
-      expect(mockDoc).toHaveBeenCalledWith('res-001')
+  it('returns residente when admin requests any resident', async () => {
+    const { docRef } = getMocks()
+    docRef.get.mockResolvedValueOnce({
+      exists: true,
+      id: residenteId,
+      data: () => sampleResidenteData,
     })
 
-    it('throws NotFoundError when document does not exist', async () => {
-      mockDocGet.mockResolvedValueOnce({ exists: false })
+    const result = await service.getResidenteById(residenteId, adminUid, 'admin')
 
-      await expect(service.getResidenteById('non-existent')).rejects.toThrow(NotFoundError)
+    expect(result.id).toBe(residenteId)
+    expect(result.nombre).toBe('Eleanor')
+    expect(result.apellidos).toBe('Vance')
+    expect(result.diagnosticos).toBe('Demencia leve')
+    // gerocultoresAsignados must NOT be in the response (stripped)
+    expect((result as Record<string, unknown>)['gerocultoresAsignados']).toBeUndefined()
+  })
+
+  it('returns residente when gerocultor is in gerocultoresAsignados', async () => {
+    const { docRef } = getMocks()
+    docRef.get.mockResolvedValueOnce({
+      exists: true,
+      id: residenteId,
+      data: () => sampleResidenteData,
     })
 
-    it('uses COLLECTIONS.residentes collection name', async () => {
-      mockDocGet.mockResolvedValueOnce({
-        exists: true,
-        id: 'res-001',
-        data: () => sampleData,
-      })
+    const result = await service.getResidenteById(residenteId, geroUid, 'gerocultor')
 
-      await service.getResidenteById('res-001')
+    expect(result.id).toBe(residenteId)
+    expect(result.nombre).toBe('Eleanor')
+  })
 
-      expect(mockCollection).toHaveBeenCalledWith('residents')
+  it('throws ForbiddenError when gerocultor is NOT in gerocultoresAsignados', async () => {
+    const { docRef } = getMocks()
+    docRef.get.mockResolvedValueOnce({
+      exists: true,
+      id: residenteId,
+      data: () => sampleResidenteData,
     })
 
-    it('maps nullable fields to null when absent from Firestore doc', async () => {
-      const minimalData = {
-        nombre: 'Juan',
-        apellidos: 'Perez',
-        fechaNacimiento: '1945-01-01',
-        habitacion: '202',
-        archivado: false,
-        creadoEn: '2026-01-01T00:00:00.000Z',
-        actualizadoEn: '2026-01-01T00:00:00.000Z',
-        // foto, diagnosticos, alergias, medicacion, preferencias absent
-      }
+    await expect(
+      service.getResidenteById(residenteId, 'other-gero-uid', 'gerocultor'),
+    ).rejects.toThrow(ForbiddenError)
+  })
 
-      mockDocGet.mockResolvedValueOnce({
-        exists: true,
-        id: 'res-002',
-        data: () => minimalData,
-      })
+  it('throws NotFoundError when resident does not exist', async () => {
+    const { docRef } = getMocks()
+    docRef.get.mockResolvedValueOnce({ exists: false, data: () => null })
 
-      const result = await service.getResidenteById('res-002')
+    await expect(
+      service.getResidenteById('non-existent-id', adminUid, 'admin'),
+    ).rejects.toThrow(NotFoundError)
+  })
 
-      expect(result.foto).toBeNull()
-      expect(result.diagnosticos).toBeNull()
-      expect(result.alergias).toBeNull()
-      expect(result.medicacion).toBeNull()
-      expect(result.preferencias).toBeNull()
+  it('returns null for optional fields when not present in Firestore doc', async () => {
+    const { docRef } = getMocks()
+    const minimalData = {
+      nombre: 'Ana',
+      apellidos: 'García',
+      fechaNacimiento: '1945-03-20',
+      habitacion: '101',
+      foto: null,
+      diagnosticos: null,
+      alergias: null,
+      medicacion: null,
+      preferencias: null,
+      archivado: false,
+      gerocultoresAsignados: [geroUid],
+      creadoEn: '2026-01-01T10:00:00Z',
+      actualizadoEn: '2026-04-01T10:00:00Z',
+    }
+
+    docRef.get.mockResolvedValueOnce({
+      exists: true,
+      id: 'res-minimal',
+      data: () => minimalData,
     })
+
+    const result = await service.getResidenteById('res-minimal', geroUid, 'gerocultor')
+
+    expect(result.foto).toBeNull()
+    expect(result.diagnosticos).toBeNull()
+    expect(result.alergias).toBeNull()
+    expect(result.medicacion).toBeNull()
+    expect(result.preferencias).toBeNull()
+  })
+
+  it('gerocultor with empty gerocultoresAsignados array gets ForbiddenError', async () => {
+    const { docRef } = getMocks()
+    docRef.get.mockResolvedValueOnce({
+      exists: true,
+      id: residenteId,
+      data: () => ({ ...sampleResidenteData, gerocultoresAsignados: [] }),
+    })
+
+    await expect(
+      service.getResidenteById(residenteId, geroUid, 'gerocultor'),
+    ).rejects.toThrow(ForbiddenError)
   })
 })

--- a/code/api/src/services/residentes.service.spec.ts
+++ b/code/api/src/services/residentes.service.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * residentes.service.spec.ts — Unit tests for ResidentesService.
+ *
+ * Firestore is fully mocked — no emulator needed.
+ * US-05: Consulta de ficha de residente
+ */
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+// Mock firebase before any service imports
+vi.mock('./firebase', () => ({
+  adminDb: {
+    collection: vi.fn(),
+  },
+}))
+
+import { adminDb } from './firebase'
+import { ResidentesService, NotFoundError } from './residentes.service'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const sampleData = {
+  nombre: 'María',
+  apellidos: 'García López',
+  fechaNacimiento: '1940-05-15',
+  habitacion: '101A',
+  foto: null,
+  diagnosticos: 'Alzheimer leve',
+  alergias: 'Penicilina',
+  medicacion: 'Donepezilo 5mg',
+  preferencias: 'Prefiere ducharse por la mañana',
+  archivado: false,
+  creadoEn: '2026-01-01T00:00:00.000Z',
+  actualizadoEn: '2026-04-01T00:00:00.000Z',
+}
+
+describe('ResidentesService', () => {
+  let service: ResidentesService
+  let mockDocGet: ReturnType<typeof vi.fn>
+  let mockDoc: ReturnType<typeof vi.fn>
+  let mockCollection: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = new ResidentesService()
+
+    mockDocGet = vi.fn()
+    mockDoc = vi.fn().mockReturnValue({ get: mockDocGet })
+    mockCollection = vi.fn().mockReturnValue({ doc: mockDoc })
+    vi.mocked(adminDb.collection).mockImplementation(mockCollection)
+  })
+
+  describe('getResidenteById', () => {
+    it('returns ResidenteResponse when document exists', async () => {
+      mockDocGet.mockResolvedValueOnce({
+        exists: true,
+        id: 'res-001',
+        data: () => sampleData,
+      })
+
+      const result = await service.getResidenteById('res-001')
+
+      expect(result.id).toBe('res-001')
+      expect(result.nombre).toBe(sampleData.nombre)
+      expect(result.apellidos).toBe(sampleData.apellidos)
+      expect(result.habitacion).toBe(sampleData.habitacion)
+      expect(result.archivado).toBe(false)
+      expect(result.foto).toBeNull()
+      expect(result.diagnosticos).toBe(sampleData.diagnosticos)
+      expect(mockDoc).toHaveBeenCalledWith('res-001')
+    })
+
+    it('throws NotFoundError when document does not exist', async () => {
+      mockDocGet.mockResolvedValueOnce({ exists: false })
+
+      await expect(service.getResidenteById('non-existent')).rejects.toThrow(NotFoundError)
+    })
+
+    it('uses COLLECTIONS.residentes collection name', async () => {
+      mockDocGet.mockResolvedValueOnce({
+        exists: true,
+        id: 'res-001',
+        data: () => sampleData,
+      })
+
+      await service.getResidenteById('res-001')
+
+      expect(mockCollection).toHaveBeenCalledWith('residents')
+    })
+
+    it('maps nullable fields to null when absent from Firestore doc', async () => {
+      const minimalData = {
+        nombre: 'Juan',
+        apellidos: 'Perez',
+        fechaNacimiento: '1945-01-01',
+        habitacion: '202',
+        archivado: false,
+        creadoEn: '2026-01-01T00:00:00.000Z',
+        actualizadoEn: '2026-01-01T00:00:00.000Z',
+        // foto, diagnosticos, alergias, medicacion, preferencias absent
+      }
+
+      mockDocGet.mockResolvedValueOnce({
+        exists: true,
+        id: 'res-002',
+        data: () => minimalData,
+      })
+
+      const result = await service.getResidenteById('res-002')
+
+      expect(result.foto).toBeNull()
+      expect(result.diagnosticos).toBeNull()
+      expect(result.alergias).toBeNull()
+      expect(result.medicacion).toBeNull()
+      expect(result.preferencias).toBeNull()
+    })
+  })
+})

--- a/code/api/src/services/residentes.service.ts
+++ b/code/api/src/services/residentes.service.ts
@@ -1,0 +1,46 @@
+import { adminDb } from './firebase'
+import { COLLECTIONS } from './collections'
+import type { ResidenteDoc, ResidenteResponse } from '../types/residente.types'
+
+export class NotFoundError extends Error {
+  readonly statusCode = 404
+  constructor(message: string) {
+    super(message)
+    this.name = 'NotFoundError'
+  }
+}
+
+function docToResponse(id: string, data: FirebaseFirestore.DocumentData): ResidenteResponse {
+  return {
+    id,
+    nombre: data['nombre'] as string,
+    apellidos: data['apellidos'] as string,
+    fechaNacimiento: data['fechaNacimiento'] as string,
+    habitacion: data['habitacion'] as string,
+    foto: (data['foto'] as string | null) ?? null,
+    diagnosticos: (data['diagnosticos'] as string | null) ?? null,
+    alergias: (data['alergias'] as string | null) ?? null,
+    medicacion: (data['medicacion'] as string | null) ?? null,
+    preferencias: (data['preferencias'] as string | null) ?? null,
+    archivado: data['archivado'] as boolean,
+    creadoEn: data['creadoEn'] as string,
+    actualizadoEn: data['actualizadoEn'] as string,
+  }
+}
+
+export class ResidentesService {
+  private get collection() {
+    return adminDb.collection(COLLECTIONS.residentes)
+  }
+
+  /**
+   * Returns the Residente with the given id.
+   * Throws NotFoundError if the document does not exist.
+   * US-05: Consulta de ficha de residente.
+   */
+  async getResidenteById(id: string): Promise<ResidenteResponse> {
+    const snap = await this.collection.doc(id).get()
+    if (!snap.exists) throw new NotFoundError('Residente not found')
+    return docToResponse(snap.id, snap.data()!)
+  }
+}

--- a/code/api/src/services/residentes.service.ts
+++ b/code/api/src/services/residentes.service.ts
@@ -1,12 +1,28 @@
+/**
+ * residentes.service.ts — Business logic + Firestore operations for Residente.
+ *
+ * US-05: Consulta de ficha de residente
+ * - Admin: can access any resident
+ * - Gerocultor: can only access residents in their gerocultoresAsignados array
+ */
 import { adminDb } from './firebase'
 import { COLLECTIONS } from './collections'
 import type { ResidenteDoc, ResidenteResponse } from '../types/residente.types'
+import type { UserRole } from '../types/user.types'
 
 export class NotFoundError extends Error {
   readonly statusCode = 404
   constructor(message: string) {
     super(message)
     this.name = 'NotFoundError'
+  }
+}
+
+export class ForbiddenError extends Error {
+  readonly statusCode = 403
+  constructor(message: string) {
+    super(message)
+    this.name = 'ForbiddenError'
   }
 }
 
@@ -33,14 +49,27 @@ export class ResidentesService {
     return adminDb.collection(COLLECTIONS.residentes)
   }
 
-  /**
-   * Returns the Residente with the given id.
-   * Throws NotFoundError if the document does not exist.
-   * US-05: Consulta de ficha de residente.
-   */
-  async getResidenteById(id: string): Promise<ResidenteResponse> {
+  async getResidenteById(
+    id: string,
+    requestingUid: string,
+    requestingRole: UserRole,
+  ): Promise<ResidenteResponse> {
     const snap = await this.collection.doc(id).get()
-    if (!snap.exists) throw new NotFoundError('Residente not found')
-    return docToResponse(snap.id, snap.data()!)
+
+    if (!snap.exists) {
+      throw new NotFoundError('Residente not found')
+    }
+
+    const data = snap.data()!
+
+    // Gerocultor access control: must be in gerocultoresAsignados array
+    if (requestingRole === 'gerocultor') {
+      const assigned = (data['gerocultoresAsignados'] as string[] | undefined) ?? []
+      if (!assigned.includes(requestingUid)) {
+        throw new ForbiddenError('No tienes acceso a este residente')
+      }
+    }
+
+    return docToResponse(snap.id, data)
   }
 }

--- a/code/api/src/types/residente.types.ts
+++ b/code/api/src/types/residente.types.ts
@@ -1,15 +1,17 @@
 import { z } from 'zod'
 
 /**
- * Zod schema and TypeScript types for the Residente entity.
+ * residente.types.ts — Domain types and Zod schemas for Residente.
+ *
  * Field names match SPEC/entities.md exactly (G04).
+ * US-05: Consulta de ficha de residente
  */
 
-/** Shape of a Residente document in Firestore. */
+/** Shape of a Residente document in Firestore. Field names match SPEC/entities.md exactly (G04). */
 export interface ResidenteDoc {
   nombre: string
   apellidos: string
-  fechaNacimiento: string // ISO 8601 string stored in Firestore
+  fechaNacimiento: string // ISO 8601 date string
   habitacion: string
   foto: string | null
   diagnosticos: string | null
@@ -17,16 +19,18 @@ export interface ResidenteDoc {
   medicacion: string | null
   preferencias: string | null
   archivado: boolean
+  gerocultoresAsignados: string[] // array of Usuario UIDs
   creadoEn: string
   actualizadoEn: string
 }
 
 /** API response shape — includes the document id. */
-export interface ResidenteResponse extends ResidenteDoc {
+export interface ResidenteResponse extends Omit<ResidenteDoc, 'gerocultoresAsignados'> {
   id: string
 }
 
-/** Zod schema for validating path param :id */
-export const ResidenteIdSchema = z.object({
-  id: z.string().min(1),
+/** Zod schema for validating :id path parameter */
+export const ResidenteIdParamSchema = z.object({
+  id: z.string().min(1, 'El id del residente es requerido'),
 })
+export type ResidenteIdParam = z.infer<typeof ResidenteIdParamSchema>

--- a/code/api/src/types/residente.types.ts
+++ b/code/api/src/types/residente.types.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+/**
+ * Zod schema and TypeScript types for the Residente entity.
+ * Field names match SPEC/entities.md exactly (G04).
+ */
+
+/** Shape of a Residente document in Firestore. */
+export interface ResidenteDoc {
+  nombre: string
+  apellidos: string
+  fechaNacimiento: string // ISO 8601 string stored in Firestore
+  habitacion: string
+  foto: string | null
+  diagnosticos: string | null
+  alergias: string | null
+  medicacion: string | null
+  preferencias: string | null
+  archivado: boolean
+  creadoEn: string
+  actualizadoEn: string
+}
+
+/** API response shape — includes the document id. */
+export interface ResidenteResponse extends ResidenteDoc {
+  id: string
+}
+
+/** Zod schema for validating path param :id */
+export const ResidenteIdSchema = z.object({
+  id: z.string().min(1),
+})


### PR DESCRIPTION
## Summary

- Implements US-05: Consulta de ficha de residente (backend API layer)
- `GET /api/residentes/:id` — returns Residente DTO or 404 NOT_FOUND
- Accessible to both `admin` and `gerocultor` roles (auth required)

## Changes

| File | Action | Description |
|------|--------|-------------|
| `src/types/residente.types.ts` | Created | Zod schema + ResidenteDoc/ResidenteResponse interfaces |
| `src/services/residentes.service.ts` | Created | ResidentesService.getResidenteById + NotFoundError |
| `src/services/residentes.service.spec.ts` | Created | Unit tests (4 cases, Firestore mocked) |
| `src/services/residentes.service.integration.spec.ts` | Created | Integration tests (Firestore Emulator) |
| `src/controllers/residentes.controller.ts` | Created | HTTP layer: getResidente handler |
| `src/controllers/residentes.controller.spec.ts` | Created | Supertest controller tests (5 cases) |
| `src/routes/residentes.routes.ts` | Created | Route definition with verifyAuth |
| `src/routes/index.ts` | Modified | Registers /api/residentes router |
| `SPEC/api/contracts/residentes.md` | Created | Delta spec for US-05 |

## Tests

- All 76 unit tests pass (`npm test`)
- Integration tests in `residentes.service.integration.spec.ts` (Firestore Emulator)

## Guardrails

- G01: US-05 exists in SPEC/user-stories.md ✅
- G03: test-plan-US-05.md exists in OUTPUTS/test-plans/ ✅
- G04: Field names match SPEC/entities.md exactly ✅
- G05: No hardcoded secrets ✅
- G08: Commit references US-05 ✅
- G10: No UI views introduced ✅