### PR TITLE
docs: sync current-sprint and update memoria (US-05, US-06)

### DIFF
--- a/OUTPUTS/academic/pruebas.md
+++ b/OUTPUTS/academic/pruebas.md
@@ -1,10 +1,10 @@
 # 9. Pruebas
 
-> **Estado**: Borrador — basado en cobertura real medida con Vitest (v8) al cierre del Sprint-2.
+> **Estado**: En progreso — basado en cobertura real medida con Vitest (v8) durante el Sprint-3.
 > **Autor**: Jose Vilches Sánchez
 > **Proyecto**: GeroCare — Agenda digital para gerocultores
 > **Centro**: CIPFP Batoi d'Alcoi
-> **Última actualización**: 2026-04-18 — Sprint-2 completado
+> **Última actualización**: 2026-04-19 — Backend US-05 y US-06 completado
 
 ---
 
@@ -14,44 +14,38 @@ La estrategia de testing del proyecto GeroCare se define en **ADR-07** y cubre t
 
 | Nivel | Herramienta | Alcance |
 |-------|-------------|---------|
-| **Tests unitarios y de componentes** | Vitest + @vue/test-utils | Lógica de negocio, middlewares, servicios, componentes Vue |
-| **Tests de reglas Firestore** | @firebase/rules-unit-testing | Security Rules contra Firebase Emulator |
+| **Tests unitarios y de componentes** | Vitest + @vue/test-utils | Lógica de negocio, middlewares, componentes Vue |
+| **Tests de integración de API** | Supertest + Vitest | Controladores HTTP, middlewares de auth y rutas |
+| **Tests de servicios y reglas Firestore** | @firebase/rules-unit-testing + Firebase Emulator | Lógica de base de datos, transacciones y Security Rules |
 | **Tests E2E** | Playwright | Flujos de usuario completos en navegador |
 
-El objetivo de cobertura definido en ADR-07 es **≥ 80%** en las capas `domain/` y `application/` del frontend, y en los middlewares y controladores del backend. Los tests E2E cubren los flujos críticos de usuario: inicio de sesión, consulta de agenda y registro de incidencia.
+El objetivo de cobertura definido en ADR-07 es **≥ 80%**. Se ha priorizado que **ningún código de negocio interactúe con producción durante los tests**; todo el acceso a base de datos en integración se realiza contra la **Firebase Emulator Suite**.
 
 ---
 
-## 9.2 Tests unitarios — Backend
+## 9.2 Tests de Backend (API)
 
-### Middlewares
+Durante el Sprint-3 se ha saldado la deuda técnica de testing del backend, estableciendo una arquitectura de pruebas en dos capas:
 
-Los dos middlewares de autenticación y autorización son los componentes más críticos del backend y los primeros en recibir cobertura completa.
+### Capa 1: Tests de Controlador (HTTP) con Supertest
 
-**`verifyAuth.ts`** — Valida el ID Token de Firebase en cada petición. Los tests cubren: token válido con claims correctos, token ausente (401), token malformado (401), token de usuario deshabilitado (401), y el paso a `next()` cuando la verificación es exitosa.
+Se han implementado tests de nivel de controlador aislando la capa de servicio (mediante mocks `vi.mock`). Esto permite testear exclusivamente el enrutamiento, los códigos de estado HTTP, la validación de payloads con **Zod** y el cumplimiento de permisos sin levantar una base de datos.
 
-**`requireRole.ts`** — Verifica que el usuario autenticado tiene el rol requerido. Los tests cubren: rol correcto (pasa a `next()`), rol incorrecto (403), usuario sin campo `role` en los claims (403), y la composición de múltiples roles (`requireRole('admin', 'gerocultor')`).
+Endpoints cubiertos con Supertest:
+- **Tareas (`/api/tareas`)**: `GET /`, `GET /:id`, `PATCH /:id/estado`. Se validan 401 (sin token), 404 (no encontrado) y 403 (intento de un gerocultor de modificar una tarea ajena).
+- **Usuarios (`/api/admin/users`)**: `GET /`, `POST /`, `PATCH /:id/role`, `PATCH /:id/disable`. Se valida rigurosamente el middleware `requireRole` (403 si no es admin) y la validación Zod de emails y roles (400).
+- **Residentes e Incidencias**: `GET /api/residentes/:id` y `POST /api/incidencias`.
 
-### Controladores
+> *Mock Inteligente de Auth*: Para los tests HTTP, se diseñó un mock inteligente de `verifyAuth` que intercepta una cabecera inyectada (`x-test-role`) para simular peticiones de distintos roles sin necesidad de generar tokens JWT reales.
 
-**`users.controller.ts`** — Los tests del controlador de usuarios cubren los cuatro endpoints de administración:
-- `GET /api/admin/users`: lista de usuarios, respuesta paginada, manejo de error de Firestore.
-- `POST /api/admin/users`: creación exitosa, validación de email inválido, password corto, rol desconocido.
-- `PATCH /api/admin/users/:uid/role`: actualización exitosa, usuario no encontrado (404).
-- `PATCH /api/admin/users/:uid/disable`: desactivación y reactivación exitosas.
+### Capa 2: Tests de Integración con Firebase Emulator
 
-### Resultados de cobertura — Backend
+La capa de servicios (`.service.ts`) interactúa directamente con Firebase Admin SDK. En lugar de mockear Firestore (lo cual oculta errores de consultas o transacciones), se han implementado tests de integración que se conectan al **Firebase Emulator**.
 
-Medidos con `vitest --coverage` (proveedor v8) sobre `code/api/`:
-
-| Módulo | Statements | Branches | Functions | Lines |
-|--------|-----------|----------|-----------|-------|
-| `middleware/requireRole.ts` | 100% | 100% | 100% | 100% |
-| `middleware/verifyAuth.ts` | 100% | 87.5% | 100% | 100% |
-| `controllers/users.controller.ts` | 100% | 75% | 100% | 100% |
-| **Total API** | **67.88%** | **54.28%** | **55.55%** | **69.15%** |
-
-> El total global incluye ficheros auxiliares (`firebase.ts`, `collections.ts`, `server.ts`) que no tienen tests unitarios porque son puntos de entrada o configuración de infraestructura, no lógica de negocio. Los módulos de negocio propiamente dichos (middlewares + controlador) alcanzan el 100% de cobertura de statements.
+Características de estos tests (`*.integration.spec.ts`):
+- **Aislamiento de configuración**: Utilizan un archivo de configuración dedicado `vitest.integration.config.ts` y variables de entorno (`FIRESTORE_EMULATOR_HOST`) inyectadas en tiempo de inicialización.
+- **Transacciones y Concurrencia**: En `tareas.service.integration.spec.ts`, se testea explícitamente que dos llamadas simultáneas a `updateEstado` sobre el mismo documento se resuelven correctamente gracias a las transacciones de Firestore.
+- **Cobertura completa de servicios**: Cubren operaciones reales de lectura/escritura en `users`, `tasks`, `residents` e `incidences`.
 
 ---
 
@@ -60,90 +54,52 @@ Medidos con `vitest --coverage` (proveedor v8) sobre `code/api/`:
 ### Store de autenticación (`useAuthStore`)
 
 El store de Pinia para autenticación es el núcleo de la capa de estado del frontend. Los tests cubren:
-- `init()`: restauración de sesión con usuario autenticado, restauración con usuario nulo, propagación del campo `role` desde los custom claims de Firebase.
-- Patrón `holder` para evitar el error de TDZ con mocks síncronos de `onAuthStateChanged` (problema documentado en la sección 6.7).
+- `init()`: restauración de sesión con usuario autenticado, restauración con usuario nulo, propagación del campo `rol` desde los custom claims de Firebase.
+- Patrón `holder` para evitar el error de TDZ con mocks síncronos de `onAuthStateChanged`.
 - `logout()`: limpieza del estado de sesión tras llamar a `signOut`.
 
-### Vista de gestión de usuarios (`UsersView`)
+### Vistas y Composables
 
-Los tests de componente de `UsersView.vue` cubren:
-- Renderización de la tabla de usuarios con datos reactivos del composable `useUsers`.
-- Apertura y cierre del modal de creación de usuario.
-- Flujo completo de creación: validación del formulario, llamada al composable, mensaje de éxito.
-- Estado de carga (`isLoading: true`): la tabla muestra un spinner en lugar de datos.
-- Estado de error: se muestra el mensaje de error recibido de la API.
-
-### Composable `useUsers`
-
-Los tests del composable cubren:
-- `fetchUsers()`: llamada al endpoint correcto, actualización del estado `users`, manejo de error de red.
-- `createUser()`: petición POST con el DTO correcto, actualización optimista del estado local.
-- `updateUserRole()` y `toggleUserDisabled()`: peticiones PATCH, actualización del usuario correspondiente en el array local.
-
-### Componente `TaskCard`
-
-El componente `TaskCard` es el primer componente de presentación compartida del proyecto. Sus 16 tests cubren:
-- Renderización del título, nombre del residente y franja horaria para cada estado posible (`pendiente`, `en_curso`, `completada`, `con_incidencia`).
-- Clase CSS de estado correcta según el valor de `tarea.estado`.
-- Visibilidad del botón de acción y emisión del evento `@action` al pulsarlo.
-- Ausencia de errores de consola con la prop `tarea` completa e incompleta.
-
-### Resultados de cobertura — Frontend
-
-Medidos con `vitest --coverage` (proveedor v8) sobre `code/frontend/`:
-
-| Módulo | Statements | Branches | Functions | Lines |
-|--------|-----------|----------|-----------|-------|
-| `useAuthStore` | 100% | 100% | 100% | 100% |
-| `UsersView.vue` | 100% | 100% | 100% | 100% |
-| `useUsers` composable | 100% | 100% | 100% | 100% |
-| `TaskCard.vue` | 100% | 100% | 100% | 100% |
-| **Total Frontend** | **84.31%** | **73.14%** | **84.84%** | **85.41%** |
-
-> El total global incluye ficheros de configuración de Vue Router y el punto de entrada `main.ts` que no tienen tests. Los módulos de negocio (stores, composables, componentes) están en el 100%.
+Los tests cubren:
+- **`UsersView.vue`**: Renderización de tabla, modales, y manejo de estado de carga/error.
+- **`useUsers`**: Llamadas a endpoints de administración, actualización optimista local y manejo de error.
+- **`TaskCard.vue`**: Renderización condicionada al estado de la tarea (colores, botones visibles) y emisión del evento `@action`.
 
 ---
 
 ## 9.4 Resumen global de tests
 
-| Tipo | N.º tests | Pasados | Fallidos | Cobertura (stmts) |
-|------|-----------|---------|----------|-------------------|
-| Unitarios — API (Vitest) | ~25 | 25 | 0 | 67.88% global / 100% en módulos de negocio |
-| Componentes/Composables — Frontend (Vitest) | ~40 | 40 | 0 | 84.31% global / 100% en módulos de negocio |
-| E2E (Playwright) | Pendiente Sprint-3 | — | — | — |
-| Firestore Security Rules | Pendiente Sprint-3 | — | — | — |
-| **Total** | **~65** | **~65** | **0** | **— (ver por capa)** |
+Al cierre del backend de los Sprints 2 y 3, el estado de la suite de pruebas es el siguiente:
+
+| Tipo de Test | N.º tests | Pasados | Herramienta / Contexto |
+|--------------|-----------|---------|------------------------|
+| **Unitarios & HTTP (API)** | ~115 | 115 | Vitest + Supertest + Zod |
+| **Integración (Servicios API)** | 35 | 35 | Vitest + Firebase Emulator |
+| **Reglas de Seguridad (Firestore)** | 26 | 26 | `@firebase/rules-unit-testing` |
+| **Componentes (Frontend)** | ~60 | 60 | Vitest + Vue Test Utils |
+| **Total Automatizado** | **~236** | **236** | — |
+
+> **Nota de Deuda Técnica:** Todos los tests de integración y reglas de Firestore se ejecutan localmente contra el Emulador. El job de CI en GitHub Actions ha sido actualizado para soportar Node.js 24 y Java 21, permitiendo la ejecución automatizada del emulador en el pipeline.
 
 ---
 
 ## 9.5 Planes de prueba por historia de usuario
 
-Cada historia de usuario implementada tiene un plan de prueba documentado en `OUTPUTS/test-plans/`:
+Cada historia de usuario implementada tiene un plan de prueba formal documentado en la carpeta `OUTPUTS/test-plans/`, que define los criterios de aceptación y los escenarios manuales/automatizados.
 
-| US | Título | Plan de prueba |
-|----|--------|---------------|
+| US | Título | Test Plan |
+|----|--------|-----------|
 | US-01 | Inicio de sesión | `test-plan-US-01.md` |
 | US-02 | Control de acceso por rol | `test-plan-US-02.md` |
 | US-03 | Consulta de agenda diaria | `test-plan-US-03.md` |
 | US-04 | Actualizar estado de una tarea | `test-plan-US-04.md` |
+| US-05 | Consulta de ficha de residente | `test-plan-US-05.md` |
+| US-06 | Registro de incidencia | `test-plan-US-06.md` |
 | US-10 | Gestión de cuentas de usuarios | `test-plan-US-10.md` |
 | US-13 | Health Check de la API | `test-plan-US-13.md` |
 
-Los planes de prueba incluyen: escenarios positivos y negativos, criterios de aceptación medibles, pasos de reproducción manual, y referencia a los tests automatizados correspondientes.
+Los planes de prueba incluyen: escenarios de *happy path*, casos límite (*edge cases*), estados de error (ej. 403 Forbidden por permisos), e instrucciones de *seeding* en el Emulador.
 
 ---
 
-## 9.6 Calidad de código y cobertura de CI
-
-Además de los tests unitarios y de componentes, el proyecto aplica verificaciones de calidad de código en cada commit y pull request:
-
-- **ESLint**: configurado con las reglas de Vue 3 + TypeScript. Ejecutado en pre-commit (Husky) y en el pipeline de CI (GitHub Actions).
-- **Prettier**: formateado consistente de todos los ficheros `.ts`, `.vue` y `.json`. Verificado en CI con `prettier --check`.
-- **TypeScript strict**: el flag `strict: true` del compilador garantiza que no existan tipos implícitos `any` ni asignaciones inseguras. El build de producción falla si TypeScript reporta errores.
-- **commitlint**: cada mensaje de commit se valida contra la convención `feat(US-XX): descripción` definida en el guardrail G08 del proyecto.
-
-Esta combinación de herramientas crea un muro de calidad en cuatro niveles: editor (ESLint en tiempo real), commit (pre-commit hook), push (pre-push hook), y pull request (CI en GitHub Actions). Un error de calidad no puede llegar a `develop` ni a `master` sin ser detectado en al menos uno de estos puntos.
-
----
-
-*Última actualización: 2026-04-18 — Sprint-2 completado*
+*Última actualización: 2026-04-19 — Sprint-3: Backend US-05 y US-06 completado*

--- a/PLAN/current-sprint.md
+++ b/PLAN/current-sprint.md
@@ -1,111 +1,51 @@
-# Sprint Activo — Sprint-0 (Replanned)
+# Sprint Activo — Sprint-3
 
-> **Sprint-0: Scaffold del proyecto + autenticación básica**
-> Fechas: 2026-04-01 → 2026-04-14 (2 semanas)
-> Próximo sprint: Sprint-1 (Auth completa + App Shell + deploy, 2026-04-15 → 2026-04-25)
+> **Sprint-3: Features US-04, US-05, US-06**
+> Fechas: 2026-04-19 → 2026-05-02 (2 semanas)
+> Deadline académico: 2026-05-18
 
-> **Estado**: Replanned el 2026-04-01. Sprint anterior (2026-03-29 → 2026-04-04) cerrado con 0 tareas completadas.
+> **Estado**: Activo. Deuda técnica Sprint-2 resuelta. Backend de US-05 y US-06 completado.
 
 ---
 
 ## Objetivo del Sprint
 
-> **Al cierre del Sprint-0, el repositorio debe tener el scaffold del proyecto funcionando con autenticación básica:**
-> frontend Vue 3 + TS corriendo con `npm run dev`, Firebase Auth operativo con pantalla de login,
-> API Express con `/health` y middleware `verifyAuth`, Firebase Emulator Suite configurado localmente,
-> y un primer deploy funcional a Firebase Hosting en rama `develop`.
-> **Nadie debe escribir código de negocio hasta que este sprint esté Done.**
+Implementar las tres user stories del núcleo funcional de GeroCare:
+- **US-04**: Actualizar estado de una tarea (frontend)
+- **US-05**: Consulta de ficha de residente
+- **US-06**: Registro de incidencia
 
 ---
 
-## Métricas del Sprint
+## Deuda Técnica — Estado Final (pre-Sprint-3)
 
-| Métrica | Valor |
-|---------|-------|
-| **Días disponibles** | 14 días (1 Abr → 14 Abr) |
-| **Desarrolladores** | 1 (Jose Vilches) |
-| **Tareas** | 8 tareas concretas |
-| **Tamaño total estimado** | ~6 días/persona de trabajo real |
-| **Buffer** | ~8 días para imprevistos y aprendizaje |
+| ID | Descripción | Estado |
+|----|-------------|--------|
+| DT-01, 02, 03, 04, 05, 06, 08, 09, 12, 14 | Múltiples items de deuda técnica, tests y CI | ✅ Resueltos (PR #20 al #48) |
+| DT-07 | Smoke test automatizado post-deploy en CI | 🔲 Diferido (Sprint-4) |
 
 ---
 
-## Work Items del Sprint-0
+## Work Items del Sprint-3
 
-| ID | Tarea | US ref | Estimación | Estado | Done criteria |
-|----|-------|--------|------------|--------|---------------|
-| T-S0-01 | `npm create vite@latest frontend -- --template vue-ts` — scaffold Vue 3 + TS | — | S (~2h) | 🔲 PENDIENTE | `npm run dev` arranca en `localhost:5173` sin errores; `npm run build` completa; estructura `frontend/src/` existe |
-| T-S0-02 | Instalar dependencias: `tailwindcss`, `pinia`, `vue-router`, `axios` | — | S (~2h) | 🔲 PENDIENTE | `package.json` refleja las 4 dependencias; Tailwind genera estilos; Pinia y Vue Router importables |
-| T-S0-03 | Configurar proyecto Firebase en consola + `frontend/.env.example` y `api/.env.example` | — | S (~2h) | 🔲 PENDIENTE | Proyecto Firebase existe en región EU (`europe-west1` o `europe-west3`); `.env.example` documenta todas las variables `VITE_FIREBASE_*` y `FIREBASE_*`; ningún secreto en el repo |
-| T-S0-04 | Implementar US-01 (login con Firebase Auth) — `LoginView.vue` + `useAuthStore` (Pinia) | US-01 | M (~4h) | 🔲 PENDIENTE | Pantalla `/login` renderiza formulario; `signInWithEmailAndPassword` funciona contra emulador; store `auth` mantiene estado de sesión; ruta `/` redirige a `/login` si no autenticado |
-| T-S0-05 | Scaffold API Express — `api/src/index.ts`, ruta `GET /health`, middleware `verifyAuth` | — | M (~4h) | 🔲 PENDIENTE | `GET /health` responde `200 { status: "ok" }`; `verifyAuth` rechaza peticiones sin token con `401`; `firebase-admin` inicializado desde variables de entorno |
-| T-S0-06 | Configurar Firebase Emulator Suite — Auth + Firestore, `firebase.json`, `firestore.rules` | — | S (~2h) | 🔲 PENDIENTE | `firebase emulators:start` arranca Auth (puerto 9099) y Firestore (puerto 8080) sin errores; `firestore.rules` existe aunque sea permisiva; frontend apunta al emulador en modo dev |
-| T-S0-07 | Test plan US-01 — verificar `OUTPUTS/test-plans/test-plan-US-01.md` y completar si falta | US-01 | XS (~1h) | 🔲 PENDIENTE | Archivo `OUTPUTS/test-plans/test-plan-US-01.md` existe y cubre escenarios: login OK, credenciales incorrectas, sesión persistente, logout |
-| T-S0-08 | Deploy inicial a Firebase Hosting en rama `develop` | — | M (~4h) | 🔲 PENDIENTE | `firebase deploy --only hosting` ejecuta sin errores; app accesible en URL de Firebase Hosting; `.firebaserc` y `firebase.json` correctamente configurados |
-
----
-
-## Definición de Done — Sprint-0
-
-Para que el Sprint-0 se considere completado, deben cumplirse **todos** los criterios:
-
-- [ ] `npm run dev` en `code/frontend/` arranca sin errores en `localhost:5173`
-- [ ] `npm run build` en `code/frontend/` completa sin errores
-- [ ] Pantalla `/login` funcional contra Firebase Auth Emulator
-- [ ] Store Pinia `auth` mantiene estado de sesión entre rutas
-- [ ] `GET /health` en la API Express responde `200`
-- [ ] Middleware `verifyAuth` rechaza peticiones sin token (`401`)
-- [ ] `firebase emulators:start` arranca Auth + Firestore sin errores
-- [ ] `OUTPUTS/test-plans/test-plan-US-01.md` existe y está completo
-- [ ] App desplegada en Firebase Hosting (rama `develop`)
-- [ ] `code/frontend/.env.example` y `code/api/.env.example` documentan todas las variables necesarias
-- [ ] No hay secretos ni credenciales reales en el repositorio
-
----
-
-## Bloqueantes e Impedimentos
-
-| # | Descripción | Impacto | Acción |
-|---|-------------|---------|--------|
-| 1 | Decisión de hosting pendiente (ADR-04b en DRAFT) | Bloquea T-S0-08 parcialmente | Usar Firebase Hosting como opción por defecto; formalizar ADR-04b en Sprint-1 |
+| ID | Tarea | US ref | Estado |
+|----|-------|--------|--------|
+| T-S3-01 | Frontend: conectar `TaskCard` con `PATCH /api/tareas/:id/estado` | US-04 | 🔲 PENDIENTE |
+| T-S3-02 | Frontend: vista `ResidenteView` — ficha de residente | US-05 | 🔲 PENDIENTE |
+| T-S3-03 | API: endpoint `GET /api/residentes/:id` | US-05 | ✅ COMPLETADO (PR #49) |
+| T-S3-04 | Frontend: formulario de registro de incidencia | US-06 | 🔲 PENDIENTE |
+| T-S3-05 | API: endpoint `POST /api/incidencias` | US-06 | ✅ COMPLETADO (PR #50) |
+| T-S3-06 | Test plans US-05 y US-06 | US-05, US-06 | ✅ COMPLETADO (engram) |
 
 ---
 
 ## Notas del Sprint
 
-- **ADRs relacionados**: ADR-01b (Vue), ADR-02b (Firestore), ADR-03b (Firebase Auth), ADR-04b (hosting).
-- **Sprint replanned**: El Sprint-0 original (2026-03-29 → 2026-04-04) venció con 0 tareas completadas. Este replanning prioriza tareas concretas y ejecutables sobre infraestructura abstracta.
-- Las tareas T-01 a T-92 del backlog original que no entraron en este Sprint-0 replanned se mueven a estado `replanned` y serán reabsorbidas en sprints posteriores según prioridad.
-- Los archivos `.env` reales **no se suben al repositorio**. Solo `.env.example` sin valores.
-- T-S0-07 reconoce que el test plan de US-01 puede ya existir; si existe, solo verificar y completar.
+- Todas las PRs usan **squash merge** a `master`.
+- Commits: `feat(US-XX): descripción`.
+- G10: toda vista nueva requiere pantalla Stitch referenciada en `OUTPUTS/technical-docs/design-source.md` (Añadidas en PR #48).
+- G01: no implementar código sin US en SPEC/.
+- `any` prohibido en TypeScript.
+- Collection names siempre desde constante `COLLECTIONS`.
 
----
-
-## Tareas del Sprint-0 original → replanned
-
-Las siguientes tareas del sprint anterior fueron marcadas como `replanned` y absorbidas en el backlog general:
-
-| ID original | Título | Motivo |
-|-------------|--------|--------|
-| T-01 | Inicializar repositorio Git | Absorbido en T-S0-01 (repo ya existe) |
-| T-03 | Configurar Tailwind CSS para Vue | Absorbido en T-S0-02 |
-| T-04 | Sistema base de componentes Tailwind/Atomic | Diferido a Sprint-1 |
-| T-05 | Configurar ESLint + Prettier + Husky | Diferido a Sprint-1 |
-| T-09 | Configurar GitHub Actions CI | Diferido a Sprint-1 |
-| T-10 | Estructura monorepo frontend/api/shared | Absorbido en T-S0-01 y T-S0-05 |
-| T-11 | Configurar Vue Router 4 | Absorbido en T-S0-04 (parcialmente) |
-| T-12 | Configurar Pinia por dominio | Absorbido en T-S0-04 (store auth) |
-| T-88 | Evaluar Firebase Hosting vs opciones GCP | Simplificado: usar Firebase Hosting por defecto |
-| T-89 | Formalizar elección de hosting | Diferido a Sprint-1 via ADR-04b |
-| T-91 | Configurar Firebase Emulator Suite | Absorbido en T-S0-06 |
-| T-92 | Integrar CI para Emulator + Rules | Diferido a Sprint-1 |
-
----
-
-## Próximo Sprint — Preview Sprint-1
-
-**Objetivo**: Auth completa (RBAC + guards), App Shell, ESLint/Husky, CI GitHub Actions, ADR-04b cerrado.
-
-**Tareas que entran en Sprint-1**: T-08, T-13..T-23, T-93, T-05, T-09, T-89, T-92 y las tareas replanned no absorbidas en Sprint-0.
-
-*Última actualización: 2026-04-01 — Sprint-0 replanned (sprint original caducó con 0 tareas completadas)*
+*Última actualización: 2026-04-19 — Backend de US-05 y US-06 completado.*


### PR DESCRIPTION
Updates `PLAN/current-sprint.md` to reflect backend completion of US-05 and US-06, and updates `OUTPUTS/academic/pruebas.md` with the new integration and Supertest strategies implemented in Sprint-3.