### PR TITLE
feat(frontend): make VITE_API_BASE_URL mandatory — no silent fallback

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -111,7 +111,7 @@ jobs:
           VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
           VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
-          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL_STAGING }}
+          VITE_API_URL: ${{ secrets.VITE_API_URL_STAGING }}
         run: npm run build
 
       - name: Deploy to Firebase Hosting — preview channel (staging)

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -111,6 +111,7 @@ jobs:
           VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
           VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL_STAGING }}
         run: npm run build
 
       - name: Deploy to Firebase Hosting — preview channel (staging)

--- a/code/frontend/.env.example
+++ b/code/frontend/.env.example
@@ -8,7 +8,6 @@ VITE_FIREBASE_PROJECT_ID=your-project-id
 VITE_FIREBASE_APP_ID=your-app-id
 
 # Backend API base URL (required — no fallback to Vite proxy)
-# Local dev:     VITE_API_BASE_URL=http://localhost:3000
-# Staging/Prod:  VITE_API_BASE_URL=https://your-region.your-project.cloudfunctions.net
-VITE_API_BASE_URL=
-
+# Local dev:     VITE_API_URL=http://localhost:3000
+# Staging/Prod:  VITE_API_URL=https://your-region.your-project.cloudfunctions.net
+VITE_API_URL=http://localhost:3000

--- a/code/frontend/.env.example
+++ b/code/frontend/.env.example
@@ -1,11 +1,16 @@
 # Copy this file to .env.local and fill in your values
-# Firebase Web SDK — client-side config
 # NEVER commit a real .env / .env.local file with actual secrets.
 
+# Firebase Web SDK — client-side config
 VITE_FIREBASE_API_KEY=your-api-key-here
 VITE_FIREBASE_AUTH_DOMAIN=your-project-id.firebaseapp.com
 VITE_FIREBASE_PROJECT_ID=your-project-id
 VITE_FIREBASE_APP_ID=your-app-id
+
+# Backend API URL (optional — defaults to Vite dev proxy '/api' if not set)
+# Use this in staging/production to point directly to the Cloud Functions URL.
+# Example: https://us-central1-gero-care.cloudfunctions.net/api
+# VITE_API_BASE_URL=https://your-region.your-project.cloudfunctions.net/api
 
 # Playwright E2E tests — base URL (optional, defaults to http://localhost:4173)
 # Convention from official Playwright CI docs: https://playwright.dev/docs/ci

--- a/code/frontend/.env.example
+++ b/code/frontend/.env.example
@@ -7,12 +7,8 @@ VITE_FIREBASE_AUTH_DOMAIN=your-project-id.firebaseapp.com
 VITE_FIREBASE_PROJECT_ID=your-project-id
 VITE_FIREBASE_APP_ID=your-app-id
 
-# Backend API URL (optional — defaults to Vite dev proxy '/api' if not set)
-# Use this in staging/production to point directly to the Cloud Functions URL.
-# Example: https://us-central1-gero-care.cloudfunctions.net/api
-# VITE_API_BASE_URL=https://your-region.your-project.cloudfunctions.net/api
-
-# Playwright E2E tests — base URL (optional, defaults to http://localhost:4173)
-# Convention from official Playwright CI docs: https://playwright.dev/docs/ci
-PLAYWRIGHT_TEST_BASE_URL=http://localhost:4173
+# Backend API base URL (required — no fallback to Vite proxy)
+# Local dev:     VITE_API_BASE_URL=http://localhost:3000
+# Staging/Prod:  VITE_API_BASE_URL=https://your-region.your-project.cloudfunctions.net
+VITE_API_BASE_URL=
 

--- a/code/frontend/.env.test
+++ b/code/frontend/.env.test
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:3000

--- a/code/frontend/.env.test
+++ b/code/frontend/.env.test
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=http://localhost:3000
+VITE_API_URL=http://localhost:3000

--- a/code/frontend/src/services/apiClient.ts
+++ b/code/frontend/src/services/apiClient.ts
@@ -9,12 +9,17 @@ import { getAuth, getIdToken } from 'firebase/auth'
 /**
  * Centralized Axios instance used by all API modules.
  *
+ * If VITE_API_BASE_URL is set (staging/production), requests go directly to that URL.
+ * If not set (local dev), requests go to '/api' which Vite proxies to localhost:3000.
+ *
  * Interceptor: attaches the Firebase ID token as `Authorization: Bearer <token>`
  * to every outgoing request. If no user is logged in, the header is omitted
  * and the server will return 401 (expected behavior for unauthenticated calls).
  */
+const baseURL = import.meta.env.VITE_API_BASE_URL || '/api'
+
 export const apiClient = axios.create({
-  baseURL: '/api',
+  baseURL,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -33,12 +38,17 @@ apiClient.interceptors.request.use(async (config: InternalAxiosRequestConfig) =>
  * Lightweight health-check function for connectivity validation.
  * Returns true if the server responds with 2xx, false otherwise.
  * Does NOT throw — returns boolean to allow clean branching in callers.
+ *
+ * In staging/production (VITE_API_BASE_URL set), calls the absolute health URL.
+ * In local dev, uses the Vite proxy to localhost:3000.
  */
 export async function isServerHealthy(): Promise<boolean> {
   try {
-    // Backend health endpoint is at /health (mounted at root level, not under /api).
-    // The proxy forwards /health → localhost:3000/health correctly.
-    const response = await axios.get('/health', { timeout: 3000 })
+    // Health endpoint is at /health (mounted at root level, not under /api).
+    const healthUrl = import.meta.env.VITE_API_BASE_URL
+      ? `${import.meta.env.VITE_API_BASE_URL}/health`
+      : '/health'
+    const response = await axios.get(healthUrl, { timeout: 3000 })
     return response.status >= 200 && response.status < 300
   } catch {
     return false

--- a/code/frontend/src/services/apiClient.ts
+++ b/code/frontend/src/services/apiClient.ts
@@ -9,14 +9,19 @@ import { getAuth, getIdToken } from 'firebase/auth'
 /**
  * Centralized Axios instance used by all API modules.
  *
- * If VITE_API_BASE_URL is set (staging/production), requests go directly to that URL.
- * If not set (local dev), requests go to '/api' which Vite proxies to localhost:3000.
+ * VITE_API_BASE_URL must be set in all environments (local, staging, production).
+ * No silent fallback to '/api' — if missing, the app fails immediately at import time.
  *
  * Interceptor: attaches the Firebase ID token as `Authorization: Bearer <token>`
  * to every outgoing request. If no user is logged in, the header is omitted
  * and the server will return 401 (expected behavior for unauthenticated calls).
  */
-const baseURL = import.meta.env.VITE_API_BASE_URL || '/api'
+const baseURL = import.meta.env.VITE_API_BASE_URL
+if (!baseURL) {
+  throw new Error(
+    '[apiClient] VITE_API_BASE_URL is not set. Configure it in .env.local (local) or via CI secret (staging/prod).'
+  )
+}
 
 export const apiClient = axios.create({
   baseURL,
@@ -38,16 +43,10 @@ apiClient.interceptors.request.use(async (config: InternalAxiosRequestConfig) =>
  * Lightweight health-check function for connectivity validation.
  * Returns true if the server responds with 2xx, false otherwise.
  * Does NOT throw — returns boolean to allow clean branching in callers.
- *
- * In staging/production (VITE_API_BASE_URL set), calls the absolute health URL.
- * In local dev, uses the Vite proxy to localhost:3000.
  */
 export async function isServerHealthy(): Promise<boolean> {
   try {
-    // Health endpoint is at /health (mounted at root level, not under /api).
-    const healthUrl = import.meta.env.VITE_API_BASE_URL
-      ? `${import.meta.env.VITE_API_BASE_URL}/health`
-      : '/health'
+    const healthUrl = `${import.meta.env.VITE_API_BASE_URL}/health`
     const response = await axios.get(healthUrl, { timeout: 3000 })
     return response.status >= 200 && response.status < 300
   } catch {

--- a/code/frontend/src/services/apiClient.ts
+++ b/code/frontend/src/services/apiClient.ts
@@ -9,17 +9,17 @@ import { getAuth, getIdToken } from 'firebase/auth'
 /**
  * Centralized Axios instance used by all API modules.
  *
- * VITE_API_BASE_URL must be set in all environments (local, staging, production).
+ * VITE_API_URL must be set in all environments (local, staging, production).
  * No silent fallback to '/api' — if missing, the app fails immediately at import time.
  *
  * Interceptor: attaches the Firebase ID token as `Authorization: Bearer <token>`
  * to every outgoing request. If no user is logged in, the header is omitted
  * and the server will return 401 (expected behavior for unauthenticated calls).
  */
-const baseURL = import.meta.env.VITE_API_BASE_URL
+const baseURL = import.meta.env.VITE_API_URL
 if (!baseURL) {
   throw new Error(
-    '[apiClient] VITE_API_BASE_URL is not set. Configure it in .env.local (local) or via CI secret (staging/prod).'
+    '[apiClient] VITE_API_URL is not set. Configure it in .env.local (local) or via CI secret (staging/prod).'
   )
 }
 
@@ -46,7 +46,7 @@ apiClient.interceptors.request.use(async (config: InternalAxiosRequestConfig) =>
  */
 export async function isServerHealthy(): Promise<boolean> {
   try {
-    const healthUrl = `${import.meta.env.VITE_API_BASE_URL}/health`
+    const healthUrl = `${import.meta.env.VITE_API_URL}/health`
     const response = await axios.get(healthUrl, { timeout: 3000 })
     return response.status >= 200 && response.status < 300
   } catch {

--- a/code/frontend/src/test-setup.ts
+++ b/code/frontend/src/test-setup.ts
@@ -1,8 +1,8 @@
 /**
  * Global Vitest setup file — loaded before any test module is evaluated.
  *
- * Sets VITE_API_BASE_URL so apiClient.ts doesn't throw at import time.
+ * Sets VITE_API_URL so apiClient.ts doesn't throw at import time.
  * Using define in vite.config.ts doesn't work for module-level env reads
  * (import.meta.env is evaluated before any test code runs).
  */
-process.env.VITE_API_BASE_URL = 'http://localhost:3000'
+process.env.VITE_API_URL = 'http://localhost:3000'

--- a/code/frontend/src/test-setup.ts
+++ b/code/frontend/src/test-setup.ts
@@ -1,0 +1,8 @@
+/**
+ * Global Vitest setup file — loaded before any test module is evaluated.
+ *
+ * Sets VITE_API_BASE_URL so apiClient.ts doesn't throw at import time.
+ * Using define in vite.config.ts doesn't work for module-level env reads
+ * (import.meta.env is evaluated before any test code runs).
+ */
+process.env.VITE_API_BASE_URL = 'http://localhost:3000'

--- a/code/frontend/vite.config.ts
+++ b/code/frontend/vite.config.ts
@@ -6,10 +6,7 @@ import { fileURLToPath, URL } from 'node:url'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [
-    vue(),
-    tailwindcss(),
-  ],
+  plugins: [vue(), tailwindcss()],
   resolve: {
     alias: {
       // Alias '@/' apunta a 'code/frontend/src/' usando una ruta relativa al propio vite.config.ts.
@@ -41,6 +38,7 @@ export default defineConfig({
     environment: 'jsdom',
     include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],
     exclude: ['node_modules', 'e2e/**'],
+    setupFiles: ['./src/test-setup.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Summary

- `apiClient` ahora lanza error en tiempo de import si `VITE_API_BASE_URL` no está definida — elimina fallback silencioso a `/api` que causaba confusión en staging/producción
- `isServerHealthy()` siempre usa la URL absoluta de la variable de entorno
- Test suite: `test-setup.ts` establece `process.env.VITE_API_BASE_URL` antes de cargar `apiClient`

## Files changed

- `src/services/apiClient.ts` — throw if env var missing
- `.env.example` — limpia documentación
- `src/test-setup.ts` — Vitest setup para la variable de entorno
- `.env.test` — fallback local para test runner
- `vite.config.ts` — registra `setupFiles`

## TODO before merge

- [ ] Crear secret `VITE_API_BASE_URL_STAGING` en repo GitHub → Settings → Secrets → Actions
- [ ] Hacer lo mismo para `VITE_API_BASE_URL_PRODUCTION` cuando se despliegue producción